### PR TITLE
Add capability to generate an object with a known ID through KnownIdGenerator.

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/util/KnownIdGenerator.java
+++ b/server/src/main/java/com/google/coffeehouse/util/KnownIdGenerator.java
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.util;
+
+/**
+ * A class that generates a known ID.
+ *
+ * <p>Used for constructing an object that alraedy has an ID.
+ */
+public class KnownIdGenerator implements IdentifierGenerator {
+  private String id;
+  
+  /** Constructor that takes in the ID it will return when generateId() is called. */
+  public KnownIdGenerator(String id) {
+    this.id = id;
+  }
+
+  /** Returns the preset id. */
+  @Override
+  public String generateId() {
+    return this.id;
+  }
+}

--- a/server/src/test/java/com/google/coffeehouse/util/KnownIdGeneratorTest.java
+++ b/server/src/test/java/com/google/coffeehouse/util/KnownIdGeneratorTest.java
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link KnownIdGenerator}.
+ */
+@RunWith(JUnit4.class)
+public class KnownIdGeneratorTest {
+  private static final String IDENTIFIER = "test identifier";
+
+  @Test
+  public void generateId() {
+    KnownIdGenerator idGen = new KnownIdGenerator(IDENTIFIER);
+    Assert.assertEquals(IDENTIFIER, idGen.generateId());
+  }
+}


### PR DESCRIPTION
When constructing a Book, Club, or Person, one can use the `.setIdGenerator` method in the builder with an instance of KnownIdGenerator if they wish to manually set the ID of the object being created (for example, constructing a Person from information stored in the database). 