### PR TITLE
Update /create-person to take input through body of POST request rather than URL parameters.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
 

--- a/server/src/main/java/com/google/coffeehouse/common/Person.java
+++ b/server/src/main/java/com/google/coffeehouse/common/Person.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 /**
  * Person encapsulates the information associated with a user who has an account.
  * 
- * <p>It implementes the {@link Saveable} interface because it will be able to save itself
+ * <p>It implements the {@link Saveable} interface because it will be able to save itself
  * in the database.
  */
 public class Person implements Saveable {

--- a/server/src/main/java/com/google/coffeehouse/common/Person.java
+++ b/server/src/main/java/com/google/coffeehouse/common/Person.java
@@ -16,6 +16,7 @@ package com.google.coffeehouse.common;
 
 import com.google.coffeehouse.util.IdentifierGenerator;
 import com.google.coffeehouse.util.UuidWrapper;
+import java.util.Map;
 import java.util.Optional; 
 
 /**
@@ -25,6 +26,15 @@ import java.util.Optional;
  * in the database.
  */
 public class Person implements Saveable {
+  /** The names of each possible field in the map in fromMap */
+  public static final String NICKNAME_FIELD_NAME = "nickname";
+  public static final String EMAIL_FIELD_NAME = "email";
+  public static final String PRONOUNS_FIELD_NAME = "pronouns";
+
+  /** The message on the IllegalArgumentException when there is no valid name or book key */
+  public static final String NO_VALID_NICKNAME_EMAIL_FROM_MAP = 
+      "No valid \"" + NICKNAME_FIELD_NAME + "\" or \"" + EMAIL_FIELD_NAME + "\" key defined.";
+  
   private String nickname;
   private String email;
   private String pronouns;
@@ -35,6 +45,41 @@ public class Person implements Saveable {
     this.email = builder.email;
     this.pronouns = builder.pronouns;
     this.userId = builder.idGenerator.generateId();
+  }
+
+  /** Overloaded static factory, calls other fromMap with null IdentifierGenerator. */
+  public static Person fromMap(Map personInfo) {
+    return Person.fromMap(personInfo, null);
+  }
+
+  /** 
+   * Creates a {@link Person} object from a Map with the relevant parameters as keys.
+   * @param personInfo the Map that contains the information used to construct the Person. At a
+   *     minimum this includes an {@code "email"} key that is mapped to a String that describes
+   *     the email of the Person to be created, as well as a {@code "nickname"} key that is mapped
+   *     to a String that describes the name of the Person to be created. A {@code "pronouns"} key
+   *     that is mapped to a String describing the pronouns of the Person can optionally be added.
+   * @param idGen the {@link IdentifierGenerator} used when constructing the Person. If
+   *     null, the default generator will be used
+   * @return the created Person
+   * @throws IllegalArgumentException if no valid {@code "email"} key or 
+   *     {@code "nickname"} key is defined
+   */
+  public static Person fromMap(Map personInfo, IdentifierGenerator idGen) {
+    String email = (String) personInfo.getOrDefault(EMAIL_FIELD_NAME, null);
+    String nickname = (String) personInfo.getOrDefault(NICKNAME_FIELD_NAME, null);
+    if (email == null || nickname == null) {
+      throw new IllegalArgumentException(NO_VALID_NICKNAME_EMAIL_FROM_MAP);
+    }
+
+    Person.Builder personBuilder = Person.newBuilder(email, nickname);
+    if (personInfo.containsKey(PRONOUNS_FIELD_NAME)) {
+      personBuilder.setPronouns((String) personInfo.get(PRONOUNS_FIELD_NAME));
+    }
+    if (idGen != null) {
+      personBuilder.setIdGenerator(idGen);
+    }
+    return personBuilder.build();
   }
 
   public String getNickname() {

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
@@ -39,7 +39,7 @@ public class CreatePersonServlet extends HttpServlet {
    */
   public static final String BODY_ERROR = "- unable to parse body.";
 
-  /** The logged error string when an error parsing the body of the POST request is encoutered */
+  /** The logged error string when an error parsing the body of the POST request is encountered */
   public static final String LOG_BODY_ERROR_MESSAGE = 
       "LOGGING: Body unable to be parsed in CreatePersonServlet: ";
   private IdentifierGenerator idGen = null;
@@ -67,7 +67,7 @@ public class CreatePersonServlet extends HttpServlet {
    *     created as its body. If this is not the case the response will send a 
    *     "400 Bad Request error"
    * @param response the response from this method, will contain the created object in JSON format.
-   *     If the request object does not have a valid JSON body that describes the Club to be 
+   *     If the request object does not have a valid JSON body that describes the Person to be 
    *     created, this object will send a "400 Bad Request error"
    * @throws IOException if an input or output error is detected when the servlet handles the request
    */

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
@@ -19,23 +19,29 @@ import com.google.coffeehouse.util.IdentifierGenerator;
 import com.google.coffeehouse.util.UuidWrapper;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** 
- * Servlet to create a {@link Person} from URL parameter input, 
+ * Servlet to create a {@link Person} from Http Post Request Body (in JSON format),
  * save it in database, and return it in JSON format.
  */
 @WebServlet("/create-person")
 public class CreatePersonServlet extends HttpServlet {
 
   /** 
-   * The error string sent by the response object in doPost when no email or nickname parameter 
-   * exists.
+   * The error string sent by the response object in doPost when the body of the 
+   * post request cannot be used to construct a {@link Person} for any reason.
    */
-  public static final String EMAIL_OR_NICKNAME_ERROR = "- email or nickname not specified.";
+  public static final String BODY_ERROR = "- unable to parse body.";
+
+  /** The logged error string when an error parsing the body of the post request is encoutered */
+  public static final String LOG_BODY_ERROR_MESSAGE = 
+      "LOGGING: Body unable to be parsed in CreatePersonServlet: ";
   private IdentifierGenerator idGen = null;
   
   /** 
@@ -56,40 +62,32 @@ public class CreatePersonServlet extends HttpServlet {
 
   /** 
    * Creates a {@link Person} object, saves it in the database and returns it in JSON format.
-   * @param request the post request that must have {@code email} and {@code nickname} defined
-   *     as parameters or the respone will send a "400 Bad Request error"
+   * @param request the post request that must have a valid JSON representation of the Person to be
+   *     created as its body. If this is not the case the response will send a 
+   *     "400 Bad Request error"
    * @param response the response from this method, will contain the created object in JSON format.
-   *     If the request object does not have {@code email} and {@code nickname} parameters, this 
-   *     object will send a "400 Bad Request error"
+   *     If the request object does not have a valid JSON body that describes the Club to be 
+   *     created, this object will send a "400 Bad Request error"
    * @throws IOException if an input or output error is detected when the servlet handles the request
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String email = request.getParameter("email");
-    String nickname = request.getParameter("nickname");
-    String pronouns = request.getParameter("pronouns");
+    String requestBody = request.getReader().lines().collect(Collectors.joining());
 
-    if (email == null || nickname == null) {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, EMAIL_OR_NICKNAME_ERROR);
+    Gson gson = new Gson();
+    Person newPerson;
+    try {
+      Map personInfo = gson.fromJson(requestBody, Map.class);
+      newPerson = Person.fromMap(personInfo, idGen);
+    } catch (Exception e) {
+      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, BODY_ERROR);
       return;
     }
 
-    // TODO: check that no other person exists with this email before creating @linamontes10
-
-    Person.Builder personBuilder = Person.newBuilder(email, nickname);
-    if (pronouns != null) {
-      personBuilder.setPronouns(pronouns);
-    }
-    // Check for dependency injection on ID generator
-    if (idGen != null) {
-      personBuilder.setIdGenerator(idGen);
-    }
-    Person newPerson = personBuilder.build();
     newPerson.save();
 
-    Gson gson = new Gson();
-    String json = gson.toJson(newPerson);
     response.setContentType("application/json;");
-    response.getWriter().println(json);
+    response.getWriter().println(gson.toJson(newPerson));
   }
 }

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** 
- * Servlet to create a {@link Person} from Http Post Request Body (in JSON format),
+ * Servlet to create a {@link Person} from Http POST Request Body (in JSON format),
  * save it in database, and return it in JSON format.
  */
 @WebServlet("/create-person")
@@ -35,11 +35,11 @@ public class CreatePersonServlet extends HttpServlet {
 
   /** 
    * The error string sent by the response object in doPost when the body of the 
-   * post request cannot be used to construct a {@link Person} for any reason.
+   * POST request cannot be used to construct a {@link Person} for any reason.
    */
   public static final String BODY_ERROR = "- unable to parse body.";
 
-  /** The logged error string when an error parsing the body of the post request is encoutered */
+  /** The logged error string when an error parsing the body of the POST request is encoutered */
   public static final String LOG_BODY_ERROR_MESSAGE = 
       "LOGGING: Body unable to be parsed in CreatePersonServlet: ";
   private IdentifierGenerator idGen = null;
@@ -62,7 +62,7 @@ public class CreatePersonServlet extends HttpServlet {
 
   /** 
    * Creates a {@link Person} object, saves it in the database and returns it in JSON format.
-   * @param request the post request that must have a valid JSON representation of the Person to be
+   * @param request the POST request that must have a valid JSON representation of the Person to be
    *     created as its body. If this is not the case the response will send a 
    *     "400 Bad Request error"
    * @param response the response from this method, will contain the created object in JSON format.

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
@@ -73,11 +73,9 @@ public class CreatePersonServlet extends HttpServlet {
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String requestBody = request.getReader().lines().collect(Collectors.joining());
-
     Person newPerson;
     try {
-      Map personInfo = gson.fromJson(requestBody, Map.class);
+      Map personInfo = gson.fromJson(request.getReader(), Map.class);
       newPerson = Person.fromMap(personInfo, idGen);
     } catch (Exception e) {
       System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
@@ -43,6 +43,7 @@ public class CreatePersonServlet extends HttpServlet {
   public static final String LOG_BODY_ERROR_MESSAGE = 
       "LOGGING: Body unable to be parsed in CreatePersonServlet: ";
   private IdentifierGenerator idGen = null;
+  private static final Gson gson = new Gson();
   
   /** 
    * Overloaded constructor for dependency injection.
@@ -74,7 +75,6 @@ public class CreatePersonServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String requestBody = request.getReader().lines().collect(Collectors.joining());
 
-    Gson gson = new Gson();
     Person newPerson;
     try {
       Map personInfo = gson.fromJson(requestBody, Map.class);

--- a/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
+++ b/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
@@ -14,14 +14,19 @@
 
 package com.google.coffeehouse.common;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.coffeehouse.util.IdentifierGenerator;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 /**
  * Unit tests for {@link Person}.
@@ -36,68 +41,104 @@ public final class PersonTest {
   private static final String ALT_PRONOUNS = "New Pronouns";
   private static final String IDENTIFICATION_STRING = "predetermined-identification-string";
   private Person.Builder personBuilder;
+  private Map personInfo;
   
   @Mock private IdentifierGenerator idGen;
 
   @Before
   public void setUp() {
-    idGen = Mockito.mock(IdentifierGenerator.class);
-    Mockito.when(idGen.generateId()).thenReturn(IDENTIFICATION_STRING);
+    personInfo = new HashMap<String, String>();
+
+    idGen = mock(IdentifierGenerator.class);
+    when(idGen.generateId()).thenReturn(IDENTIFICATION_STRING);
 
     personBuilder = Person.newBuilder(EMAIL, NICKNAME);
   }
 
   @Test
-  public void getExistingNickname() {
+  public void getNickname_exists() {
     Person p = personBuilder.build();
     Assert.assertEquals(NICKNAME, p.getNickname());
   }
 
   @Test
-  public void getExistingEmail() {
+  public void getEmail_exists() {
     Person p = personBuilder.build();
     Assert.assertEquals(EMAIL, p.getEmail());
   }
 
   @Test
-  public void getExistingUserId() {
+  public void getUserId_exists() {
     Person p = personBuilder.setIdGenerator(idGen).build();
     Assert.assertEquals(IDENTIFICATION_STRING, p.getUserId());
   }
 
   @Test
-  public void getExistingPronouns() {
+  public void getPronouns_exists() {
     Person p = personBuilder.setPronouns(PRONOUNS).build();
     Assert.assertTrue(p.getPronouns().isPresent());
     Assert.assertEquals(PRONOUNS, p.getPronouns().get());
   }
 
   @Test
-  public void getNoPronouns() {
+  public void getPronouns_notExist() {
     Person p = personBuilder.build();
     Assert.assertFalse(p.getPronouns().isPresent());
   }
 
   @Test
-  public void setNewNickname() {
+  public void setNickname() {
     Person p = personBuilder.build();
     p.setNickname(ALT_NICKNAME);
     Assert.assertEquals(ALT_NICKNAME, p.getNickname());
   }
 
   @Test
-  public void setNewEmail() {
+  public void setEmail() {
     Person p = personBuilder.build();
     p.setEmail(ALT_EMAIL);
     Assert.assertEquals(ALT_EMAIL, p.getEmail());
   }
 
   @Test
-  public void setNewPronouns() {
+  public void setPronouns() {
     Person p = personBuilder.build();
     p.setPronouns(ALT_PRONOUNS);
     Assert.assertTrue(p.getPronouns().isPresent());
     Assert.assertEquals(ALT_PRONOUNS, p.getPronouns().get());
+  }
+
+  @Test 
+  public void fromMap_invalidInput() {
+    personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
+    Assert.assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
+        @Override
+        public void run() throws Throwable {
+          Person.fromMap(personInfo);
+        }
+    });
+  }
+
+  @Test 
+  public void fromMap_minimumValidInput() {
+    personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
+    personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
+    Person p = Person.fromMap(personInfo);
+    Assert.assertEquals(NICKNAME, p.getNickname());
+    Assert.assertEquals(EMAIL, p.getEmail());
+    Assert.assertFalse(p.getPronouns().isPresent());
+  }
+
+  @Test 
+  public void fromMap_maximumValidInput() {
+    personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
+    personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
+    personInfo.put(Person.PRONOUNS_FIELD_NAME, PRONOUNS);
+    Person p = Person.fromMap(personInfo);
+    Assert.assertEquals(NICKNAME, p.getNickname());
+    Assert.assertEquals(EMAIL, p.getEmail());
+    Assert.assertTrue(p.getPronouns().isPresent());
+    Assert.assertEquals(PRONOUNS, p.getPronouns().get());
   }
 
   // TODO: test saving @linamontes10

--- a/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
+++ b/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
@@ -111,11 +111,8 @@ public final class PersonTest {
   @Test 
   public void fromMap_invalidInput() {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
-    Assert.assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-        @Override
-        public void run() throws Throwable {
-          Person.fromMap(personInfo);
-        }
+    Assert.assertThrows(IllegalArgumentException.class, () -> {
+      Person.fromMap(personInfo);
     });
   }
 

--- a/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
+++ b/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
@@ -112,7 +112,7 @@ public final class PersonTest {
   public void fromMap_invalidInput() {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
     assertThrows(IllegalArgumentException.class, () -> {
-      Person.fromMap(personInfo);
+        Person.fromMap(personInfo);
     });
   }
 

--- a/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
+++ b/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
@@ -14,13 +14,13 @@
 
 package com.google.coffeehouse.common;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.coffeehouse.util.IdentifierGenerator;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
@@ -58,60 +58,60 @@ public final class PersonTest {
   @Test
   public void getNickname_exists() {
     Person p = personBuilder.build();
-    Assert.assertEquals(NICKNAME, p.getNickname());
+    assertEquals(NICKNAME, p.getNickname());
   }
 
   @Test
   public void getEmail_exists() {
     Person p = personBuilder.build();
-    Assert.assertEquals(EMAIL, p.getEmail());
+    assertEquals(EMAIL, p.getEmail());
   }
 
   @Test
   public void getUserId_exists() {
     Person p = personBuilder.setIdGenerator(idGen).build();
-    Assert.assertEquals(IDENTIFICATION_STRING, p.getUserId());
+    assertEquals(IDENTIFICATION_STRING, p.getUserId());
   }
 
   @Test
   public void getPronouns_exists() {
     Person p = personBuilder.setPronouns(PRONOUNS).build();
-    Assert.assertTrue(p.getPronouns().isPresent());
-    Assert.assertEquals(PRONOUNS, p.getPronouns().get());
+    assertTrue(p.getPronouns().isPresent());
+    assertEquals(PRONOUNS, p.getPronouns().get());
   }
 
   @Test
   public void getPronouns_notExist() {
     Person p = personBuilder.build();
-    Assert.assertFalse(p.getPronouns().isPresent());
+    assertFalse(p.getPronouns().isPresent());
   }
 
   @Test
   public void setNickname() {
     Person p = personBuilder.build();
     p.setNickname(ALT_NICKNAME);
-    Assert.assertEquals(ALT_NICKNAME, p.getNickname());
+    assertEquals(ALT_NICKNAME, p.getNickname());
   }
 
   @Test
   public void setEmail() {
     Person p = personBuilder.build();
     p.setEmail(ALT_EMAIL);
-    Assert.assertEquals(ALT_EMAIL, p.getEmail());
+    assertEquals(ALT_EMAIL, p.getEmail());
   }
 
   @Test
   public void setPronouns() {
     Person p = personBuilder.build();
     p.setPronouns(ALT_PRONOUNS);
-    Assert.assertTrue(p.getPronouns().isPresent());
-    Assert.assertEquals(ALT_PRONOUNS, p.getPronouns().get());
+    assertTrue(p.getPronouns().isPresent());
+    assertEquals(ALT_PRONOUNS, p.getPronouns().get());
   }
 
   @Test 
   public void fromMap_invalidInput() {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       Person.fromMap(personInfo);
     });
   }
@@ -121,9 +121,9 @@ public final class PersonTest {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
     personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
     Person p = Person.fromMap(personInfo);
-    Assert.assertEquals(NICKNAME, p.getNickname());
-    Assert.assertEquals(EMAIL, p.getEmail());
-    Assert.assertFalse(p.getPronouns().isPresent());
+    assertEquals(NICKNAME, p.getNickname());
+    assertEquals(EMAIL, p.getEmail());
+    assertFalse(p.getPronouns().isPresent());
   }
 
   @Test 
@@ -132,10 +132,10 @@ public final class PersonTest {
     personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
     personInfo.put(Person.PRONOUNS_FIELD_NAME, PRONOUNS);
     Person p = Person.fromMap(personInfo);
-    Assert.assertEquals(NICKNAME, p.getNickname());
-    Assert.assertEquals(EMAIL, p.getEmail());
-    Assert.assertTrue(p.getPronouns().isPresent());
-    Assert.assertEquals(PRONOUNS, p.getPronouns().get());
+    assertEquals(NICKNAME, p.getNickname());
+    assertEquals(EMAIL, p.getEmail());
+    assertTrue(p.getPronouns().isPresent());
+    assertEquals(PRONOUNS, p.getPronouns().get());
   }
 
   // TODO: test saving @linamontes10

--- a/server/src/test/java/com/google/coffeehouse/servlets/CreatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/CreatePersonServletTest.java
@@ -14,6 +14,7 @@
 
 package com.google.coffeehouse.servlets;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -30,7 +31,6 @@ import java.io.StringWriter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -103,9 +103,9 @@ public class CreatePersonServletTest {
     Gson gson = new Gson();
     Person p = gson.fromJson(result, Person.class);
 
-    Assert.assertEquals(NICKNAME, p.getNickname());
-    Assert.assertEquals(EMAIL, p.getEmail());
-    Assert.assertFalse(p.getPronouns().isPresent());
+    assertEquals(NICKNAME, p.getNickname());
+    assertEquals(EMAIL, p.getEmail());
+    assertFalse(p.getPronouns().isPresent());
   }
 
   @Test
@@ -119,10 +119,10 @@ public class CreatePersonServletTest {
     Gson gson = new Gson();
     Person p = gson.fromJson(result, Person.class);
 
-    Assert.assertEquals(NICKNAME, p.getNickname());
-    Assert.assertEquals(EMAIL, p.getEmail());
-    Assert.assertTrue(p.getPronouns().isPresent());
-    Assert.assertEquals(PRONOUNS, p.getPronouns().get());
+    assertEquals(NICKNAME, p.getNickname());
+    assertEquals(EMAIL, p.getEmail());
+    assertTrue(p.getPronouns().isPresent());
+    assertEquals(PRONOUNS, p.getPronouns().get());
   }
 
   @Test


### PR DESCRIPTION
The /create-person servlet previously used URL parameters as input when creating a Person object. This was inconsistent with how /create-club works, and thus I have updated /create-person to work by parsing JSON found in the body of the POST request (the method used in /create-club).