### PR TITLE
Fixed flaky bug of environment variable sometimes not being set.

### DIFF
--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,10 +1,13 @@
 # Runs both dev servers at the same time, can be ended at the same time with ctrl+C
 echo "Preview on http://localhost:9000"
 
+PROJECT="coffeehouse-step2020"
+
 if [[ $* == *-s* ]]
 then
   (cd frontend; npm install) &&
-  gcloud config set project coffeehouse-step2020 &&
+  gcloud config set project $PROJECT &&
+  GOOGLE_CLOUD_PROJECT=$PROJECT &&
   sudo sysctl -w fs.inotify.max_user_watches=100000
 fi
 


### PR DESCRIPTION
Once in a while, `bash run-dev.sh -s` would cause an error in the tests, but only when changing the current gcloud project. This was traced back to a call to the method `getProjectId()` from the class `SpannerOptions`. This call references the `GOOGLE_CLOUD_PROJECT` environment variable to determine the project ID, which would sometimes not be set in time by the `gcloud config set project coffeehouse-step2020` command in `run-dev.sh`. The fix is to explicitly set the `GOOGLE_CLOUD_PROJECT` environment variable after setting the gcloud project.