### PR TITLE
Refactor Person to allow setting of userId in builder directly.

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/common/Person.java
+++ b/server/src/main/java/com/google/coffeehouse/common/Person.java
@@ -60,9 +60,15 @@ public class Person implements Saveable {
    */
   public static Person fromMap(Map personInfo) {
     Person.Builder personBuilder = Person.newBuilder();
-    personBuilder.setNickname((String) personInfo.getOrDefault(NICKNAME_FIELD_NAME, null));
-    personBuilder.setEmail((String) personInfo.getOrDefault(EMAIL_FIELD_NAME, null));
-    personBuilder.setUserId((String) personInfo.getOrDefault(USERID_FIELD_NAME, null));
+    if (personInfo.containsKey(NICKNAME_FIELD_NAME)) {
+      personBuilder.setNickname((String) personInfo.get(NICKNAME_FIELD_NAME));
+    }
+    if (personInfo.containsKey(EMAIL_FIELD_NAME)) {
+      personBuilder.setEmail((String) personInfo.get(EMAIL_FIELD_NAME));
+    }
+    if (personInfo.containsKey(USERID_FIELD_NAME)) {
+      personBuilder.setUserId((String) personInfo.get(USERID_FIELD_NAME));
+    }
     if (personInfo.containsKey(PRONOUNS_FIELD_NAME)) {
       personBuilder.setPronouns((String) personInfo.get(PRONOUNS_FIELD_NAME));
     }

--- a/server/src/main/java/com/google/coffeehouse/common/Person.java
+++ b/server/src/main/java/com/google/coffeehouse/common/Person.java
@@ -31,7 +31,7 @@ public class Person implements Saveable {
   /** The name of the pronouns field in the map in fromMap. */
   public static final String PRONOUNS_FIELD_NAME = "pronouns";
   /** The name of the userId field in the map in fromMap. */
-  public static final String USERID_FIELD_NAME = "userId";
+  public static final String USER_ID_FIELD_NAME = "userId";
   
   private String nickname;
   private String email;
@@ -66,8 +66,8 @@ public class Person implements Saveable {
     if (personInfo.containsKey(EMAIL_FIELD_NAME)) {
       personBuilder.setEmail((String) personInfo.get(EMAIL_FIELD_NAME));
     }
-    if (personInfo.containsKey(USERID_FIELD_NAME)) {
-      personBuilder.setUserId((String) personInfo.get(USERID_FIELD_NAME));
+    if (personInfo.containsKey(USER_ID_FIELD_NAME)) {
+      personBuilder.setUserId((String) personInfo.get(USER_ID_FIELD_NAME));
     }
     if (personInfo.containsKey(PRONOUNS_FIELD_NAME)) {
       personBuilder.setPronouns((String) personInfo.get(PRONOUNS_FIELD_NAME));

--- a/server/src/main/java/com/google/coffeehouse/common/Person.java
+++ b/server/src/main/java/com/google/coffeehouse/common/Person.java
@@ -55,7 +55,7 @@ public class Person implements Saveable {
    *     A {@code "pronouns"} key that is mapped to a String describing the pronouns of the Person
    *     can optionally be added
    * @return the created Person
-   * @throws RuntimeException if no valid {@code "email"} key or 
+   * @throws IllegalStateException if no valid {@code "email"} key or 
    *     {@code "nickname"} key or {@code "userId"} key is defined
    */
   public static Person fromMap(Map personInfo) {
@@ -148,13 +148,13 @@ public class Person implements Saveable {
 
     public Person build() {
       if (email == null) {
-        throw new RuntimeException("Person must be instantiated with a non-null email");
+        throw new IllegalStateException("Person must be instantiated with a non-null email");
       }
       if (nickname == null) {
-        throw new RuntimeException("Person must be instantiated with a non-null nickname");
+        throw new IllegalStateException("Person must be instantiated with a non-null nickname");
       }
       if (userId == null) {
-        throw new RuntimeException("Person must be instantiated with a non-null userId");
+        throw new IllegalStateException("Person must be instantiated with a non-null userId");
       }
       return new Person(this);
     }

--- a/server/src/main/java/com/google/coffeehouse/common/Person.java
+++ b/server/src/main/java/com/google/coffeehouse/common/Person.java
@@ -55,7 +55,7 @@ public class Person implements Saveable {
    *     A {@code "pronouns"} key that is mapped to a String describing the pronouns of the Person
    *     can optionally be added
    * @return the created Person
-   * @throws IllegalArgumentException if no valid {@code "email"} key or 
+   * @throws RuntimeException if no valid {@code "email"} key or 
    *     {@code "nickname"} key or {@code "userId"} key is defined
    */
   public static Person fromMap(Map personInfo) {

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreatePersonServlet.java
@@ -15,8 +15,6 @@
 package com.google.coffeehouse.servlets;
 
 import com.google.coffeehouse.common.Person;
-import com.google.coffeehouse.util.IdentifierGenerator;
-import com.google.coffeehouse.util.UuidWrapper;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Map;
@@ -32,7 +30,6 @@ import javax.servlet.http.HttpServletResponse;
  */
 @WebServlet("/api/create-person")
 public class CreatePersonServlet extends HttpServlet {
-
   /** 
    * The error string sent by the response object in doPost when the body of the 
    * POST request cannot be used to construct a {@link Person} for any reason.
@@ -42,24 +39,7 @@ public class CreatePersonServlet extends HttpServlet {
   /** The logged error string when an error parsing the body of the POST request is encountered */
   public static final String LOG_BODY_ERROR_MESSAGE = 
       "LOGGING: Body unable to be parsed in CreatePersonServlet: ";
-  private IdentifierGenerator idGen = null;
   private static final Gson gson = new Gson();
-  
-  /** 
-   * Overloaded constructor for dependency injection.
-   * @param idGen the {@link IdentifierGenerator} that is used when constructing the Person
-   */
-  public CreatePersonServlet(IdentifierGenerator idGen) {
-    super();
-    this.idGen = idGen;
-  }
-
-  /** 
-   * Explicit default constructor used for instantiating the servlet when not testing.
-   */
-  public CreatePersonServlet() {
-    super();
-  }
 
   /** 
    * Creates a {@link Person} object, saves it in the database and returns it in JSON format.
@@ -76,7 +56,7 @@ public class CreatePersonServlet extends HttpServlet {
     Person newPerson;
     try {
       Map personInfo = gson.fromJson(request.getReader(), Map.class);
-      newPerson = Person.fromMap(personInfo, idGen);
+      newPerson = Person.fromMap(personInfo);
     } catch (Exception e) {
       System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, BODY_ERROR);

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -38,7 +38,6 @@ import java.util.List;
 * The StorageHandler class holds the functions that either get information from the
 * database and return the respective objects created with that information, or
 * perform transactions to the database.
-* .
 */
 public class StorageHandler {
   public static final String NO_PRONOUNS = "No pronouns";
@@ -68,12 +67,12 @@ public class StorageHandler {
               Arrays.asList("email", "nickname", "pronouns"));
     if (row != null) {
       Person.Builder personBuilder = Person.newBuilder()
-                                           .setEmail(row.getString(/*emailIndex=*/0))
-                                           .setNickname(row.getString(/*nicknameIndex=*/1))
+                                           .setEmail(row.getString(/* emailIndex= */0))
+                                           .setNickname(row.getString(/* nicknameIndex= */1))
                                            .setUserId(userId);
 
-      if (!row.isNull(/*index=*/2) || !row.getString(/*index=*/2).isEmpty()) {
-        personBuilder.setPronouns(row.getString(/*pronounsIndex=*/2));
+      if (!row.isNull(/* index= */2) || !row.getString(/* index= */2).isEmpty()) {
+        personBuilder.setPronouns(row.getString(/* pronounsIndex= */2));
       }
       return personBuilder.build();
     } else {
@@ -98,14 +97,14 @@ public class StorageHandler {
               Key.of(bookId),
               Arrays.asList("title", "autho", "isbn"));
     if (row != null) {
-      Book.Builder bookBuilder = Book.newBuilder(row.getString(/*titleIndex=*/0));
+      Book.Builder bookBuilder = Book.newBuilder(row.getString(/* titleIndex= */0));
       // TODO: implement setting the bookId field @JosephBushagour
 
-      if (!row.isNull(/*index=*/1) || !row.getString(/*index=*/1).isEmpty()) {
-        bookBuilder.setAuthor(row.getString(/*authorIndex=*/1));
+      if (!row.isNull(/* index= */1) || !row.getString(/* index= */1).isEmpty()) {
+        bookBuilder.setAuthor(row.getString(/* authorIndex= */1));
       }
-      if (!row.isNull(/*index=*/2) || !row.getString(/*index=*/2).isEmpty()) {
-        bookBuilder.setIsbn(row.getString(/*isbnIndex=*/2));
+      if (!row.isNull(/* index= */2) || !row.getString(/* index= */2).isEmpty()) {
+        bookBuilder.setIsbn(row.getString(/* isbnIndex= */2));
       }
       return bookBuilder.build();
     } else {
@@ -130,12 +129,12 @@ public class StorageHandler {
             Key.of(clubId),
             Arrays.asList("bookId", "name", "description", "ownerId"));
     if (row != null) {
-      Book book = getBook(dbClient, row.getString(/*bookIdIndex=*/0));
-      Club.Builder clubBuilder = Club.newBuilder(row.getString(/*nameIndex=*/1),
+      Book book = getBook(dbClient, row.getString(/* bookIdIndex= */0));
+      Club.Builder clubBuilder = Club.newBuilder(row.getString(/* nameIndex= */1),
                                                  book);
       // TODO: implement setting the clubId field @JosephBushagour
       // TODO: implement setting the ownerId field @JosephBushagour
-      clubBuilder.setDescription(row.getString(/*descriptionIndex=*/2));
+      clubBuilder.setDescription(row.getString(/* descriptionIndex= */2));
       return clubBuilder.build();
     } else {
       throw new IllegalArgumentException(CLUB_DOES_NOT_EXIST);
@@ -225,7 +224,7 @@ public class StorageHandler {
                 KeySet.range(KeyRange.prefix(Key.of(clubId))),
                 Arrays.asList("userId"));
       while (resultSet.next()) {
-        persons.add(getPerson(dbClient, resultSet.getString(/**userIdIndex=**/0)));
+        persons.add(getPerson(dbClient, resultSet.getString(/* userIdIndex= */0)));
       }
     }
     return persons;
@@ -267,7 +266,7 @@ public class StorageHandler {
       resultSet = dbClient.singleUse().executeQuery(statement);
     }
     while (resultSet.next()) {
-      clubs.add(getClub(dbClient, resultSet.getString(/**clubIdIndex=**/0)));
+      clubs.add(getClub(dbClient, resultSet.getString(/* clubIdIndex= */0)));
     }
     return clubs;
   }

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -67,9 +67,11 @@ public class StorageHandler {
               Key.of(userId),
               Arrays.asList("email", "nickname", "pronouns"));
     if (row != null) {
-      Person.Builder personBuilder = Person.newBuilder(row.getString(/*emailIndex=*/0),
-                                                       row.getString(/*nicknameIndex=*/1));
-      // TODO: implement setting the userId field @JosephBushagour
+      Person.Builder personBuilder = Person.newBuilder()
+                                           .setEmail(row.getString(/*emailIndex=*/0))
+                                           .setNickname(row.getString(/*nicknameIndex=*/1))
+                                           .setUserId(userId);
+
       if (!row.isNull(/*index=*/2) || !row.getString(/*index=*/2).isEmpty()) {
         personBuilder.setPronouns(row.getString(/*pronounsIndex=*/2));
       }

--- a/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
+++ b/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.coffeehouse.util.IdentifierGenerator;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -39,20 +38,15 @@ public final class PersonTest {
   private static final String ALT_EMAIL = "New Email";
   private static final String PRONOUNS = "she/her";
   private static final String ALT_PRONOUNS = "New Pronouns";
-  private static final String IDENTIFICATION_STRING = "predetermined-identification-string";
+  private static final String USERID = "predetermined-identification-string";
   private Person.Builder personBuilder;
   private Map personInfo;
   
-  @Mock private IdentifierGenerator idGen;
-
   @Before
   public void setUp() {
     personInfo = new HashMap<String, String>();
 
-    idGen = mock(IdentifierGenerator.class);
-    when(idGen.generateId()).thenReturn(IDENTIFICATION_STRING);
-
-    personBuilder = Person.newBuilder(EMAIL, NICKNAME);
+    personBuilder = Person.newBuilder().setEmail(EMAIL).setNickname(NICKNAME).setUserId(USERID);
   }
 
   @Test
@@ -69,8 +63,8 @@ public final class PersonTest {
 
   @Test
   public void getUserId_exists() {
-    Person p = personBuilder.setIdGenerator(idGen).build();
-    assertEquals(IDENTIFICATION_STRING, p.getUserId());
+    Person p = personBuilder.build();
+    assertEquals(USERID, p.getUserId());
   }
 
   @Test
@@ -111,7 +105,7 @@ public final class PersonTest {
   @Test 
   public void fromMap_invalidInput() {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
-    assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(RuntimeException.class, () -> {
         Person.fromMap(personInfo);
     });
   }
@@ -120,9 +114,11 @@ public final class PersonTest {
   public void fromMap_minimumValidInput() {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
     personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
+    personInfo.put(Person.USERID_FIELD_NAME, USERID);
     Person p = Person.fromMap(personInfo);
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
+    assertEquals(USERID, p.getUserId());
     assertFalse(p.getPronouns().isPresent());
   }
 
@@ -131,9 +127,11 @@ public final class PersonTest {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
     personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
     personInfo.put(Person.PRONOUNS_FIELD_NAME, PRONOUNS);
+    personInfo.put(Person.USERID_FIELD_NAME, USERID);
     Person p = Person.fromMap(personInfo);
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
+    assertEquals(USERID, p.getUserId());
     assertTrue(p.getPronouns().isPresent());
     assertEquals(PRONOUNS, p.getPronouns().get());
   }

--- a/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
+++ b/server/src/test/java/com/google/coffeehouse/common/PersonTest.java
@@ -38,7 +38,7 @@ public final class PersonTest {
   private static final String ALT_EMAIL = "New Email";
   private static final String PRONOUNS = "she/her";
   private static final String ALT_PRONOUNS = "New Pronouns";
-  private static final String USERID = "predetermined-identification-string";
+  private static final String USER_ID = "predetermined-identification-string";
   private Person.Builder personBuilder;
   private Map personInfo;
   
@@ -46,7 +46,7 @@ public final class PersonTest {
   public void setUp() {
     personInfo = new HashMap<String, String>();
 
-    personBuilder = Person.newBuilder().setEmail(EMAIL).setNickname(NICKNAME).setUserId(USERID);
+    personBuilder = Person.newBuilder().setEmail(EMAIL).setNickname(NICKNAME).setUserId(USER_ID);
   }
 
   @Test
@@ -64,7 +64,7 @@ public final class PersonTest {
   @Test
   public void getUserId_exists() {
     Person p = personBuilder.build();
-    assertEquals(USERID, p.getUserId());
+    assertEquals(USER_ID, p.getUserId());
   }
 
   @Test
@@ -114,11 +114,11 @@ public final class PersonTest {
   public void fromMap_minimumValidInput() {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
     personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
-    personInfo.put(Person.USERID_FIELD_NAME, USERID);
+    personInfo.put(Person.USER_ID_FIELD_NAME, USER_ID);
     Person p = Person.fromMap(personInfo);
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
-    assertEquals(USERID, p.getUserId());
+    assertEquals(USER_ID, p.getUserId());
     assertFalse(p.getPronouns().isPresent());
   }
 
@@ -127,11 +127,11 @@ public final class PersonTest {
     personInfo.put(Person.NICKNAME_FIELD_NAME, NICKNAME);
     personInfo.put(Person.EMAIL_FIELD_NAME, EMAIL);
     personInfo.put(Person.PRONOUNS_FIELD_NAME, PRONOUNS);
-    personInfo.put(Person.USERID_FIELD_NAME, USERID);
+    personInfo.put(Person.USER_ID_FIELD_NAME, USER_ID);
     Person p = Person.fromMap(personInfo);
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
-    assertEquals(USERID, p.getUserId());
+    assertEquals(USER_ID, p.getUserId());
     assertTrue(p.getPronouns().isPresent());
     assertEquals(PRONOUNS, p.getPronouns().get());
   }

--- a/server/src/test/java/com/google/coffeehouse/servlets/CreatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/CreatePersonServletTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Person;
-import com.google.coffeehouse.util.IdentifierGenerator;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -42,17 +41,19 @@ public class CreatePersonServletTest {
   private static final String NICKNAME = "Tim";
   private static final String EMAIL = "test@fake.fake";
   private static final String PRONOUNS = "he/him";
-  private static final String IDENTIFICATION_STRING = "predetermined-identification-string";
+  private static final String USERID = "predetermined-identification-string";
   private static final String MINIMUM_JSON = String.join("\n", 
       "{",
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
-      "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\"",
+      "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\",",
+      "  \"" + Person.USERID_FIELD_NAME + "\" : \"" + USERID + "\"",
       "}");
   private static final String MAXIMUM_JSON = String.join("\n", 
       "{",
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
       "  \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + PRONOUNS + "\",",
-      "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\"",
+      "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\",",
+      "  \"" + Person.USERID_FIELD_NAME + "\" : \"" + USERID + "\"",
       "}");
   private static final String NO_NICKNAME_JSON = String.join("\n", 
       "{",
@@ -63,6 +64,12 @@ public class CreatePersonServletTest {
       "{",
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
       "  \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + PRONOUNS + "\"",
+      "}");
+  private static final String NO_USERID_JSON = String.join("\n", 
+      "{",
+      "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
+      "  \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + PRONOUNS + "\",",
+      "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\"",
       "}");
   private static final String SYNTACTICALLY_INCORRECT_JSON = 
       "{\"" + Person.NICKNAME_FIELD_NAME + "\"";
@@ -78,9 +85,7 @@ public class CreatePersonServletTest {
   public void setUp() throws IOException {
     helper.setUp();
 
-    IdentifierGenerator idGen = mock(IdentifierGenerator.class);
-    when(idGen.generateId()).thenReturn(IDENTIFICATION_STRING);
-    CreatePersonServlet = new CreatePersonServlet(idGen);
+    CreatePersonServlet = new CreatePersonServlet();
 
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
@@ -105,6 +110,7 @@ public class CreatePersonServletTest {
 
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
+    assertEquals(USERID, p.getUserId());
     assertFalse(p.getPronouns().isPresent());
   }
 
@@ -121,6 +127,7 @@ public class CreatePersonServletTest {
 
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
+    assertEquals(USERID, p.getUserId());
     assertTrue(p.getPronouns().isPresent());
     assertEquals(PRONOUNS, p.getPronouns().get());
   }
@@ -139,6 +146,16 @@ public class CreatePersonServletTest {
   public void doPost_noNicknameSpecified() throws IOException {
     when(request.getReader()).thenReturn(
           new BufferedReader(new StringReader(NO_NICKNAME_JSON)));
+    CreatePersonServlet.doPost(request, response);
+    
+    verify(response).sendError(
+        HttpServletResponse.SC_BAD_REQUEST, CreatePersonServlet.BODY_ERROR);
+  }
+
+  @Test
+  public void doPost_noUserIdSpecified() throws IOException {
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(NO_USERID_JSON)));
     CreatePersonServlet.doPost(request, response);
     
     verify(response).sendError(

--- a/server/src/test/java/com/google/coffeehouse/servlets/CreatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/CreatePersonServletTest.java
@@ -41,19 +41,19 @@ public class CreatePersonServletTest {
   private static final String NICKNAME = "Tim";
   private static final String EMAIL = "test@fake.fake";
   private static final String PRONOUNS = "he/him";
-  private static final String USERID = "predetermined-identification-string";
+  private static final String USER_ID = "predetermined-identification-string";
   private static final String MINIMUM_JSON = String.join("\n", 
       "{",
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
       "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\",",
-      "  \"" + Person.USERID_FIELD_NAME + "\" : \"" + USERID + "\"",
+      "  \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "}");
   private static final String MAXIMUM_JSON = String.join("\n", 
       "{",
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
       "  \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + PRONOUNS + "\",",
       "  \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + EMAIL + "\",",
-      "  \"" + Person.USERID_FIELD_NAME + "\" : \"" + USERID + "\"",
+      "  \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "}");
   private static final String NO_NICKNAME_JSON = String.join("\n", 
       "{",
@@ -65,7 +65,7 @@ public class CreatePersonServletTest {
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
       "  \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + PRONOUNS + "\"",
       "}");
-  private static final String NO_USERID_JSON = String.join("\n", 
+  private static final String NO_USER_ID_JSON = String.join("\n", 
       "{",
       "  \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + NICKNAME + "\",",
       "  \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + PRONOUNS + "\",",
@@ -110,7 +110,7 @@ public class CreatePersonServletTest {
 
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
-    assertEquals(USERID, p.getUserId());
+    assertEquals(USER_ID, p.getUserId());
     assertFalse(p.getPronouns().isPresent());
   }
 
@@ -127,7 +127,7 @@ public class CreatePersonServletTest {
 
     assertEquals(NICKNAME, p.getNickname());
     assertEquals(EMAIL, p.getEmail());
-    assertEquals(USERID, p.getUserId());
+    assertEquals(USER_ID, p.getUserId());
     assertTrue(p.getPronouns().isPresent());
     assertEquals(PRONOUNS, p.getPronouns().get());
   }
@@ -155,7 +155,7 @@ public class CreatePersonServletTest {
   @Test
   public void doPost_noUserIdSpecified() throws IOException {
     when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(NO_USERID_JSON)));
+          new BufferedReader(new StringReader(NO_USER_ID_JSON)));
     CreatePersonServlet.doPost(request, response);
     
     verify(response).sendError(


### PR DESCRIPTION
Previously, it was impossible (well, very annoying) to set the ID of a person to a known ID during creation. This was a mistake, and is fixed with this PR.