### PR TITLE
Add functionality for /get-profile servlet

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -38,11 +38,11 @@ public class GetProfileServlet extends HttpServlet {
    */
   public static final String BODY_ERROR = "- unable to parse body.";
 
-  /** The logged error string when an error parsing the body of the GET request is encountered */
+  /** The logged error string when an error parsing the body of the GET request is encountered. */
   public static final String LOG_BODY_ERROR_MESSAGE = 
       "Body unable to be parsed in GetProfileServlet: ";
 
-  /** Message to be logged when the body of the POST request does not have required fields. */
+  /** Message to be logged when the body of the GET request does not have required fields. */
   public static final String LOG_INPUT_ERROR_MESSAGE =
       "Error with JSON input in GetProfileServlet: No \"userId\" found in JSON.";
 

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -81,7 +81,7 @@ public class GetProfileServlet extends HttpServlet {
     Person person;
     try {
       Map userInfo = gson.fromJson(request.getReader(), Map.class);
-      // TODO: Change to actual oauth parameter from json that is passed in @JoeyBushagour
+      // TODO: Change to actual oauth parameter from json that is passed in @JoeyBushagour.
       String userId = (String) userInfo.get(Person.USER_ID_FIELD_NAME);
       if (userId == null) {
         throw new IllegalArgumentException(LOG_INPUT_ERROR_MESSAGE);

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -26,7 +26,8 @@ import javax.servlet.http.HttpServletResponse;
 
 /** 
  * Servlet to get a {@link Person} from Http GET Request Body (in JSON format)
- * that exists in the database, and return it in JSON format.
+ * that exists in the database through a call to the Storage Handler API,
+ * and return it in JSON format.
  */
 @WebServlet("/api/get-profile")
 public class GetProfileServlet extends HttpServlet {

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -42,6 +42,23 @@ public class GetProfileServlet extends HttpServlet {
   public static final String LOG_BODY_ERROR_MESSAGE = 
       "Body unable to be parsed in GetProfileServlet: ";
   private static final Gson gson = new Gson();
+  private StorageHandlerApi storageHandler = new StorageHandlerApi();
+
+  /**
+   * Overloaded constructor for dependency injection.
+   * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Person
+   */
+  public GetProfileServlet(StorageHandlerApi storageHandler) {
+    super();
+    this.storageHandler = storageHandler;
+  }
+
+  /**
+   * Explicity default constructor used for instantiating the servlet when not testing.
+   */
+  public GetProfileServlet() {
+    super();
+  }
   
   /** 
    * Returns a {@link Person} object in JSON format from information in the database.
@@ -60,7 +77,7 @@ public class GetProfileServlet extends HttpServlet {
       Map userInfo = gson.fromJson(request.getReader(), Map.class);
       // TODO: Change to actual oauth parameter from json that is passed in @JoeyBushagour
       String userId = userInfo.get("userId").toString();
-      person = StorageHandlerApi.fetchPersonFromId(userId);
+      person = storageHandler.fetchPersonFromId(userId);
     } catch (Exception e) {
       System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, BODY_ERROR);

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -1,0 +1,71 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.servlets;
+
+import com.google.coffeehouse.common.Person;
+import com.google.coffeehouse.StorageHandler.StorageHandlerApi;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.Map;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** 
+ * Servlet to get a {@link Person} from Http GET Request Body (in JSON format)
+ * that exists in the database, and return it in JSON format.
+ */
+@WebServlet("/api/get-profile")
+public class GetProfileServlet extends HttpServlet {
+
+  /** 
+   * The error string sent by the response object in doGet when the body of the 
+   * GET request cannot be used to fetch a {@link Person} for any reason.
+   */
+  public static final String BODY_ERROR = "- unable to parse body.";
+
+  /** The logged error string when an error parsing the body of the GET request is encountered */
+  public static final String LOG_BODY_ERROR_MESSAGE = 
+      "LOGGING: Body unable to be parsed in GetProfileServlet: ";
+  private static final Gson gson = new Gson();
+  
+  /** 
+   * Returns a {@link Person} object in JSON format from information in the database.
+   * @param request the GET request that must have a valid JSON representation of the userId to be
+   *     passed in order to fetch a person from ID in the database. If this is not the case the
+   *     response will send a "400 Bad Request error"
+   * @param response the response from this method, will contain the object in JSON format.
+   *     If the request object does not have a valid JSON body that describes the Person, this object
+   *     will send a "400 Bad Request error"
+   * @throws IOException if an input or output error is detected when the servlet handles the request
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Person person;
+    try {
+      Map userInfo = gson.fromJson(request.getReader(), Map.class);
+      // TODO: Change to actual oauth parameter from json that is passed in @JoeyBushagour
+      String userId = userInfo.get("userId");
+      person = StorageHandlerApi.fetchPersonFromId(userId);
+    } catch (Exception e) {
+      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, BODY_ERROR);
+      return;
+    }
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(person));
+  }
+}

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -15,7 +15,7 @@
 package com.google.coffeehouse.servlets;
 
 import com.google.coffeehouse.common.Person;
-import com.google.coffeehouse.StorageHandler.StorageHandlerApi;
+import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Map;
@@ -58,7 +58,7 @@ public class GetProfileServlet extends HttpServlet {
     try {
       Map userInfo = gson.fromJson(request.getReader(), Map.class);
       // TODO: Change to actual oauth parameter from json that is passed in @JoeyBushagour
-      String userId = userInfo.get("userId");
+      String userId = userInfo.get("userId").toString();
       person = StorageHandlerApi.fetchPersonFromId(userId);
     } catch (Exception e) {
       System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -16,6 +16,7 @@ package com.google.coffeehouse.servlets;
 
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
+import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class GetProfileServlet extends HttpServlet {
    */
   public GetProfileServlet(StorageHandlerApi storageHandler) {
     super();
-    this.storageHandler = new StorageHandlerApi();
+    this.storageHandler = storageHandler;
   }
 
   /**
@@ -89,11 +90,16 @@ public class GetProfileServlet extends HttpServlet {
       person = storageHandler.fetchPersonFromId(userId);
     } catch (IllegalArgumentException e) {
       System.out.println(e.getMessage());
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+      if (e.getMessage() == StorageHandler.PERSON_DOES_NOT_EXIST) {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND,
+                           StorageHandler.PERSON_DOES_NOT_EXIST);
+      } else {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+      }
       return;
     } catch (Exception e) {
       System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, BODY_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, BODY_ERROR);
       return;
     }
     response.setContentType("application/json;");

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -39,7 +39,7 @@ public class GetProfileServlet extends HttpServlet {
 
   /** The logged error string when an error parsing the body of the GET request is encountered */
   public static final String LOG_BODY_ERROR_MESSAGE = 
-      "LOGGING: Body unable to be parsed in GetProfileServlet: ";
+      "Body unable to be parsed in GetProfileServlet: ";
   private static final Gson gson = new Gson();
   
   /** 

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerApi.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerApi.java
@@ -38,7 +38,7 @@ public class StorageHandlerApi {
   * @param  userId    the user ID string used to query the Persons table from the database
   * @return           a Person object containing information from the database
   */
-  public static Person fetchPersonFromId(String userId) {
+  public Person fetchPersonFromId(String userId) {
     return StorageHandler.getPerson(dbClient, userId);
   }
 
@@ -48,7 +48,7 @@ public class StorageHandlerApi {
   * @param  clubId    the club ID string used to query the Clubs table from the database.
   * @return           a Club object containing information from the database
   */
-  public static Club fetchClubFromId(String clubId) {
+  public Club fetchClubFromId(String clubId) {
     return StorageHandler.getClub(dbClient, clubId);
   }
 
@@ -58,7 +58,7 @@ public class StorageHandlerApi {
   * @param  clubId    the club ID used to retrieve a list of members
   * @return           a list of Person objects that are members of a club
   */
-  public static List<Person> fetchMembersByClubId(String clubId) {
+  public List<Person> fetchMembersByClubId(String clubId) {
     return StorageHandler.getListOfMembers(dbClient, clubId);
   }
 
@@ -69,7 +69,7 @@ public class StorageHandlerApi {
   * @param  userId      the user ID string specifying the person who is being added as a member
   * @param  clubId      the club ID string specifying the club a person is being added to
   */
-  public static void addMembership(String userId, String clubId) {
+  public void addMembership(String userId, String clubId) {
     StorageHandler.runAddMembershipTransaction(dbClient, userId, clubId);
   }
 
@@ -80,7 +80,7 @@ public class StorageHandlerApi {
   * @param  userId      the user ID string specifying the person who is leaving a club
   * @param  clubId      the club ID string specifying the club a person is leaving
   */
-  public static void deleteMembership(String userId, String clubId) {
+  public void deleteMembership(String userId, String clubId) {
     StorageHandler.runDeleteMembershipTransaction(dbClient, userId, clubId);
   }
 
@@ -91,7 +91,7 @@ public class StorageHandlerApi {
   * @param  membershipStatus  the enum specifying whether the user is a member or not
   * @return                   the list of {@link Club}s
   */
-  public static List<Club> listClubsFromUserId(String userId, MembershipConstants.MembershipStatus membershipStatus) {
+  public List<Club> listClubsFromUserId(String userId, MembershipConstants.MembershipStatus membershipStatus) {
     return StorageHandler.getListOfClubs(dbClient, userId, membershipStatus);
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -41,7 +41,9 @@ import org.mockito.Mock;
 public class GetProfileServletTest {
   // TODO: Change field name to be appropriate
   private static final String USER_ID = "predetermined-identification-string";
-  private static final String JSON = String.join("\n", 
+  private static final String EMAIL = "email@test.com";
+  private static final String NICKNAME = "test";
+  private static final String JSON = String.join("\n",
       "{",
       "  \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "}");
@@ -79,7 +81,11 @@ public class GetProfileServletTest {
     String result = stringWriter.toString();
 
     Gson gson = new Gson();
-    Person p = gson.fromJson(result, Person.class);
+    Person.Builder personBuilder = Person.newBuilder()
+                                         .setEmail(EMAIL)
+                                         .setNickname(NICKNAME)
+                                         .setUserId(USER_ID);
+    Person p = personBuilder.build();
 
     assertEquals(USER_ID, p.getUserId());
   }

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 /**
  * Unit tests for {@link GetProfileServlet}.
  */
-public class getProfileServletTest {
+public class GetProfileServletTest {
   // TODO: Change field name to be appropriate
   private static final String USER_ID = "predetermined-identification-string";
   private static final String JSON = String.join("\n", 

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -82,8 +82,8 @@ public class GetProfileServletTest {
 
     failingHandler = mock(StorageHandlerApi.class);
     when(failingHandler.fetchPersonFromId(anyString()))
-                       .thenThrow(new IllegalArgumentException(StorageHandler.PERSON_DOES_NOT_EXIST))
-                       .thenReturn(null);
+                       .thenThrow(new IllegalArgumentException(
+                                      StorageHandler.PERSON_DOES_NOT_EXIST));
     failingGetProfileServlet = new GetProfileServlet(failingHandler);
 
     request = mock(HttpServletRequest.class);

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -17,6 +17,8 @@ package com.google.coffeehouse.servlets;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
@@ -35,7 +37,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.Mock;
+import org.mockito.Spy;
 
 /**
  * Unit tests for {@link GetProfileServlet}.
@@ -108,6 +112,9 @@ public class GetProfileServletTest {
     Person p = gson.fromJson(result, Person.class);
 
     assertEquals(USER_ID, p.getUserId());
+    assertEquals(EMAIL, p.getEmail());
+    assertEquals(NICKNAME, p.getNickname());
+    assertEquals(PRONOUNS, p.getPronouns().get());
   }
 
   @Test
@@ -128,7 +135,7 @@ public class GetProfileServletTest {
     failingGetProfileServlet.doGet(request, response);
     
     verify(response).sendError(
-        HttpServletResponse.SC_BAD_REQUEST,
+        HttpServletResponse.SC_NOT_FOUND,
         StorageHandler.PERSON_DOES_NOT_EXIST);
   }
 
@@ -139,7 +146,7 @@ public class GetProfileServletTest {
     getProfileServlet.doGet(request, response);
     
     verify(response).sendError(
-        HttpServletResponse.SC_BAD_REQUEST,
+        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
         GetProfileServlet.BODY_ERROR);
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mock;
  * Unit tests for {@link GetProfileServlet}.
  */
 public class GetProfileServletTest {
-  // TODO: Change field name to be appropriate
   private static final String USER_ID = "predetermined-identification-string";
   private static final String EMAIL = "email@test.com";
   private static final String NICKNAME = "test";

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -40,14 +40,13 @@ import org.mockito.Mock;
  */
 public class getProfileServletTest {
   // TODO: Change field name to be appropriate
-  private static final String USER_ID_FIELD_NAME = "userId";
-  private static final String USER_ID_STRING = "predetermined-identification-string";
+  private static final String USER_ID = "predetermined-identification-string";
   private static final String JSON = String.join("\n", 
       "{",
-      "  \"" + USER_ID_FIELD_NAME + "\" : \"" + USER_ID_STRING + "\"",
+      "  \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "}");
   private static final String SYNTACTICALLY_INCORRECT_JSON = 
-      "{\"" + USER_ID_FIELD_NAME + "\"";
+      "{\"" + Person.USER_ID_FIELD_NAME + "\"";
 
   private GetProfileServlet GetProfileServlet;
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
@@ -59,7 +58,7 @@ public class getProfileServletTest {
   @Before
   public void setUp() throws IOException {
     helper.setUp();
-    GetProfileServlet = new getProfileServlet();
+    GetProfileServlet = new GetProfileServlet();
 
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
@@ -82,7 +81,7 @@ public class getProfileServletTest {
     Gson gson = new Gson();
     Person p = gson.fromJson(result, Person.class);
 
-    assertEquals(USER_ID_STRING, p.getUserId());
+    assertEquals(USER_ID, p.getUserId());
   }
 
   @Test

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.servlets;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.coffeehouse.common.Person;
+import com.google.coffeehouse.storagehandler.StorageHandlerApi;
+import com.google.gson.Gson;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * Unit tests for {@link GetProfileServlet}.
+ */
+public class getProfileServletTest {
+  // TODO: Change field name to be appropriate
+  private static final String USER_ID_FIELD_NAME = "userId";
+  private static final String USER_ID_STRING = "predetermined-identification-string";
+  private static final String JSON = String.join("\n", 
+      "{",
+      "  \"" + USER_ID_FIELD_NAME + "\" : \"" + USER_ID_STRING + "\"",
+      "}");
+  private static final String SYNTACTICALLY_INCORRECT_JSON = 
+      "{\"" + USER_ID_FIELD_NAME + "\"";
+
+  private GetProfileServlet GetProfileServlet;
+  private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
+  private StringWriter stringWriter = new StringWriter();
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  
+  @Before
+  public void setUp() throws IOException {
+    helper.setUp();
+    GetProfileServlet = new getProfileServlet();
+
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void doGet_validInput() throws IOException {
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(JSON)));
+
+    GetProfileServlet.doGet(request, response);
+    String result = stringWriter.toString();
+
+    Gson gson = new Gson();
+    Person p = gson.fromJson(result, Person.class);
+
+    assertEquals(USER_ID_STRING, p.getUserId());
+  }
+
+  @Test
+  public void doGet_syntacticallyIncorrectInput() throws IOException {
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(SYNTACTICALLY_INCORRECT_JSON)));
+    GetProfileServlet.doGet(request, response);
+    
+    verify(response).sendError(
+        HttpServletResponse.SC_BAD_REQUEST, GetProfileServlet.BODY_ERROR);
+  }
+}


### PR DESCRIPTION
Creation of the /get-profile servlet allows for the fetching of information about a person from the database by user ID using the `fetchPersonFromId` method in the Storage Handler API, and returns a Person object in JSON format.
The closing of this PR is contingent upon changes in Joey's PR #43 that allow for the setting of a user ID in the builder. 
Closes issue #37 .