### PR TITLE
Add /api/list-clubs which returns a JSON array of clubs that the user is (not) a member of.

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
@@ -130,7 +130,7 @@ public class ListClubsServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     List<Club> clubs;
     try {
-      // Get the userId after validating the user's ID token
+      // Get the userId after validating the user's ID token.
       Map requestInfo = gson.fromJson(request.getReader(), Map.class);
       String idToken = (String) requestInfo.get(ID_TOKEN_FIELD_NAME);
       String userId = AuthenticationHelper.getUserIdFromIdToken(idToken, verifier);

--- a/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
@@ -1,0 +1,165 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.servlets;
+
+import static com.google.coffeehouse.common.MembershipConstants.MembershipStatus;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.coffeehouse.common.Club;
+import com.google.coffeehouse.common.Person;
+import com.google.coffeehouse.storagehandler.StorageHandlerApi;
+import com.google.coffeehouse.storagehandler.StorageHandler;
+import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Map;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet to get a list of Clubs that a user is in (or not in) and return it in JSON format.
+ *
+ * <p>TODO: There is currently no pagination implemented in this servlet. In the future,
+ * pagination should be supported, as it will allow this code to be used even when the 
+ * number of clubs in our database increases.
+ */
+@WebServlet("/api/list-clubs")
+public class ListClubsServlet extends HttpServlet {
+  /**
+   * The error string sent by the response object in doGet when the body of the 
+   * GET request cannot be be parsed.
+   */
+  public static final String BODY_ERROR = "- unable to parse body.";
+  /** The logged error string when an error parsing the body of the GET request is encountered. */
+  public static final String LOG_BODY_ERROR_MESSAGE =
+      "Body unable to be parsed in ListClubsServlet: ";
+  /** Message to be logged when the body of the GET request does not have required fields. */
+  public static final String LOG_INPUT_ERROR_MESSAGE =
+      "Error with JSON input in ListClubsServlet: No \"%s\" found in JSON.";
+  /**
+   * Message to be logged when an invalid ID token is passed in or a no ID token is passed in.
+   */
+  public static final String LOG_SECURITY_MESSAGE =
+      "Forbidden action attempted: ";
+  /** Name of the key in the input JSON that corresponds to the ID token. */
+  public static final String ID_TOKEN_FIELD_NAME =
+      "idToken";
+  /**
+   * Name of the key in the input JSON that corresponds to if we are searching for clubs the user
+   * is a member of, or clubs that the user is not a member of.
+   */
+  public static final String MEMBERSHIP_STATUS_FIELD_NAME =
+      "membershipStatus";
+  /**
+   * A possible value for the MEMBERSHIP_STATUS_FIELD_NAME key that means we are searching for
+   * clubs that the user is a member of.
+   */
+  public static final String MEMBER =
+      "member";
+  /**
+   * A possible value for the MEMBERSHIP_STATUS_FIELD_NAME key that means we are searching for
+   * clubs that the user is not a member of.
+   */
+  public static final String NOT_MEMBER =
+      "not member";
+
+  private static final Gson gson = new Gson();
+  private static final HttpTransport transport = new NetHttpTransport();
+  private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+  private final GoogleIdTokenVerifier verifier;
+  private final StorageHandlerApi storageHandler;
+
+  /** 
+   * Overloaded constructor for dependency injection.
+   * @param verifier the class that verifies the validity of the ID token
+   * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Clubs
+   */
+  public ListClubsServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+    super();
+    this.storageHandler = storageHandler;
+    this.verifier = verifier;
+  }
+
+  /** 
+   * Explicit default constructor used for instantiating the servlet when not testing.
+   */
+  public ListClubsServlet() {
+    super();
+    this.storageHandler = new StorageHandlerApi();
+    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+  }
+
+  /**
+   * Responds with a JSON list of {@link Club} objects that a user is either a member of or not.
+   * @param request the GET request that must have the {@code "idToken"} of the user who wants
+   *     a list of clubs that they are in (or not in) back. It must also have a
+   *     {@code "membershipStatus"} key which is mapped to either "member" or "not member". This
+   *     key determines if we return a list of clubs where the user is a member, or not a member.
+   *     If the required "membershipStatus" field does not exist, the response object
+   *     will send a "400 Bad Request error". If the JSON body is not valid, and unable to be
+   *     parsed, the response object will send a "500 Internal Server error". If the "idToken"
+   *     field is missing or invalid, the response object will send a "403 Forbidden error"
+   * @param response the response from this method, will contain the list of Clubs in JSON format.
+   *     If the required "membershipStatus" field does not exist in the request
+   *     object, this object will send a "400 Bad Request error". If the JSON body is not valid,
+   *     and unable to be parsed, this object will send a "500 Internal Server error". If the
+   *     "idToken" field is missing or invalid, the response object will send a
+   *     "403 Forbidden error"
+   * @throws IOException if an input or output error is detected when the servlet handles the request
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    List<Club> clubs;
+    try {
+      // Get the userId after validating the user's ID token
+      Map requestInfo = gson.fromJson(request.getReader(), Map.class);
+      String idToken = (String) requestInfo.get(ID_TOKEN_FIELD_NAME);
+      String userId = AuthenticationHelper.getUserIdFromIdToken(idToken, verifier);
+
+      String status = (String) requestInfo.get(MEMBERSHIP_STATUS_FIELD_NAME);
+      if (status == null || !(status.equals(MEMBER) || status.equals(NOT_MEMBER))) {
+        throw new IllegalArgumentException(
+            String.format(LOG_INPUT_ERROR_MESSAGE, MEMBERSHIP_STATUS_FIELD_NAME));
+      }
+
+      MembershipStatus membershipStatus = status.equals(MEMBER)
+          ? MembershipStatus.MEMBER
+          : MembershipStatus.NOT_MEMBER;
+      
+      clubs = storageHandler.listClubsFromUserId(userId, membershipStatus);
+    } catch (IllegalArgumentException e) {
+      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+      return;
+    } catch (GeneralSecurityException e) {
+      System.out.println(LOG_SECURITY_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
+      return;
+    } catch (Exception e) {
+      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, BODY_ERROR);
+      return;
+    }
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(clubs));
+  }
+}

--- a/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
@@ -58,29 +58,24 @@ public class ListClubsServlet extends HttpServlet {
   /**
    * Message to be logged when an invalid ID token is passed in or a no ID token is passed in.
    */
-  public static final String LOG_SECURITY_MESSAGE =
-      "Forbidden action attempted: ";
+  public static final String LOG_SECURITY_MESSAGE = "Forbidden action attempted: ";
   /** Name of the key in the input JSON that corresponds to the ID token. */
-  public static final String ID_TOKEN_FIELD_NAME =
-      "idToken";
+  public static final String ID_TOKEN_FIELD_NAME = "idToken";
   /**
    * Name of the key in the input JSON that corresponds to if we are searching for clubs the user
    * is a member of, or clubs that the user is not a member of.
    */
-  public static final String MEMBERSHIP_STATUS_FIELD_NAME =
-      "membershipStatus";
+  public static final String MEMBERSHIP_STATUS_FIELD_NAME = "membershipStatus";
   /**
    * A possible value for the MEMBERSHIP_STATUS_FIELD_NAME key that means we are searching for
    * clubs that the user is a member of.
    */
-  public static final String MEMBER =
-      "member";
+  public static final String MEMBER = "member";
   /**
    * A possible value for the MEMBERSHIP_STATUS_FIELD_NAME key that means we are searching for
    * clubs that the user is not a member of.
    */
-  public static final String NOT_MEMBER =
-      "not member";
+  public static final String NOT_MEMBER = "not member";
 
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();

--- a/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
@@ -1,0 +1,240 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.servlets;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static com.google.coffeehouse.common.MembershipConstants.MembershipStatus;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.coffeehouse.common.Book;
+import com.google.coffeehouse.common.Club;
+import com.google.coffeehouse.common.Person;
+import com.google.coffeehouse.storagehandler.StorageHandlerApi;
+import com.google.coffeehouse.storagehandler.StorageHandler;
+import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.gson.Gson;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * Unit tests for {@link ListClubsServlet}.
+ */
+public class ListClubsServletTest {
+  private static final String NAME = "Club Name";
+  private static final String DESCRIPTION = "Club Description";
+  private static final String CLUB_ID = "predetermined-identification-string";
+  private static final String OWNER_ID = "predetermined-owner-identification-string";
+  private static final String BOOK_TITLE = "Book Name";
+  private static final String BOOK_ID = "predetermined-book-identification-string";
+  private static final String ID_TOKEN = "Identification Token";
+  private List<String> testContentWarnings = new ArrayList<>(Arrays.asList("1", "2"));
+  private Book testBook = Book.newBuilder()
+                              .setTitle(BOOK_TITLE)
+                              .setBookId(BOOK_ID)
+                              .build();
+  private Club testClub = Club.newBuilder()
+                              .setName(NAME)
+                              .setCurrentBook(testBook)
+                              .setOwnerId(OWNER_ID)
+                              .setClubId(CLUB_ID)
+                              .setDescription(DESCRIPTION)
+                              .setContentWarnings(testContentWarnings)
+                              .build();
+  private static final String VALID_JSON_MEMBER = String.join("\n",
+      "{",
+      "  \"" + UpdateClubServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
+      "  \"" + ListClubsServlet.MEMBERSHIP_STATUS_FIELD_NAME + "\" : \"" 
+             + ListClubsServlet.MEMBER + "\"",
+      "}");
+  private static final String VALID_JSON_NOT_MEMBER = String.join("\n",
+      "{",
+      "  \"" + UpdateClubServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
+      "  \"" + ListClubsServlet.MEMBERSHIP_STATUS_FIELD_NAME + "\" : \"" 
+             + ListClubsServlet.NOT_MEMBER + "\"",
+      "}");
+  private static final String NO_MEMBERSHIP_STATUS = String.join("\n",
+      "{",
+      "  \"" + UpdateClubServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\"",
+      "}");
+  private static final String NO_ID_TOKEN = String.join("\n",
+      "{",
+      "  \"" + ListClubsServlet.MEMBERSHIP_STATUS_FIELD_NAME + "\" : \"" 
+             + ListClubsServlet.NOT_MEMBER + "\"",
+      "}");
+  private static final String SYNTACTICALLY_INCORRECT_JSON =
+      "{\"" + Person.USER_ID_FIELD_NAME + "\"";
+
+  private ListClubsServlet listClubsServlet;
+  private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
+  private StringWriter stringWriter = new StringWriter();
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private StorageHandlerApi memberHandler;
+  @Mock private StorageHandlerApi notMemberHandler;
+  @Mock private GoogleIdTokenVerifier verifier;
+  @Mock private GoogleIdTokenVerifier nullVerifier;
+  @Mock private GoogleIdToken idToken;
+  @Mock private Payload payload;
+
+  @Before
+  public void setUp() throws IOException, GeneralSecurityException {
+    helper.setUp();
+
+    memberHandler = mock(StorageHandlerApi.class);
+    when(memberHandler.listClubsFromUserId(
+        anyString(), eq(MembershipStatus.MEMBER))).thenReturn(Arrays.asList(testClub));
+
+    notMemberHandler = mock(StorageHandlerApi.class);
+    when(notMemberHandler.listClubsFromUserId(
+        anyString(), eq(MembershipStatus.NOT_MEMBER))).thenReturn(Arrays.asList(testClub));
+
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+    
+    // Verification setup that successfully verifies and gives userId.
+    payload = mock(Payload.class);
+    when(payload.getSubject()).thenReturn(OWNER_ID);
+    idToken = mock(GoogleIdToken.class);
+    when(idToken.getPayload()).thenReturn(payload);
+    verifier = mock(GoogleIdTokenVerifier.class);
+    when(verifier.verify(anyString())).thenReturn(idToken);
+
+    // Verification setup that does not successfully verify.
+    nullVerifier = mock(GoogleIdTokenVerifier.class);
+    when(nullVerifier.verify(anyString())).thenReturn(null);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void doGet_validInputMember() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, memberHandler);
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(VALID_JSON_MEMBER)));
+
+    listClubsServlet.doGet(request, response);
+    String result = stringWriter.toString();
+
+    Gson gson = new Gson();
+    Club[] clubs = gson.fromJson(result, Club[].class);
+
+    assertEquals(1, clubs.length);
+    Club c = clubs[0];
+    assertEquals(NAME, c.getName());
+    assertEquals(OWNER_ID, c.getOwnerId());
+    assertEquals(CLUB_ID, c.getClubId());
+    assertEquals(DESCRIPTION, c.getDescription());
+    assertEquals(testContentWarnings, c.getContentWarnings());
+    assertEquals(BOOK_TITLE, c.getCurrentBook().getTitle());
+    assertEquals(BOOK_ID, c.getCurrentBook().getBookId());
+  }
+
+  @Test
+  public void doGet_validInputNotMember() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, notMemberHandler);
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(VALID_JSON_NOT_MEMBER)));
+
+    listClubsServlet.doGet(request, response);
+    String result = stringWriter.toString();
+
+    Gson gson = new Gson();
+    Club[] clubs = gson.fromJson(result, Club[].class);
+
+    assertEquals(1, clubs.length);
+    Club c = clubs[0];
+    assertEquals(NAME, c.getName());
+    assertEquals(OWNER_ID, c.getOwnerId());
+    assertEquals(CLUB_ID, c.getClubId());
+    assertEquals(DESCRIPTION, c.getDescription());
+    assertEquals(testContentWarnings, c.getContentWarnings());
+    assertEquals(BOOK_TITLE, c.getCurrentBook().getTitle());
+    assertEquals(BOOK_ID, c.getCurrentBook().getBookId());
+  }
+
+  @Test
+  public void doGet_noMembershipStatus() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, memberHandler);
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(NO_MEMBERSHIP_STATUS)));
+    listClubsServlet.doGet(request, response);
+
+    verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST,
+        String.format(ListClubsServlet.LOG_INPUT_ERROR_MESSAGE,
+                      ListClubsServlet.MEMBERSHIP_STATUS_FIELD_NAME));
+  }
+
+  @Test
+  public void doGet_noIdToken() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, memberHandler);
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(NO_ID_TOKEN)));
+    listClubsServlet.doGet(request, response);
+
+    verify(response).sendError(
+        HttpServletResponse.SC_FORBIDDEN,
+        AuthenticationHelper.INVALID_ID_TOKEN_ERROR);
+  }
+
+  @Test
+  public void doGet_syntacticallyIncorrectInput() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, memberHandler);
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(SYNTACTICALLY_INCORRECT_JSON)));
+    listClubsServlet.doGet(request, response);
+
+    verify(response).sendError(
+        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+        ListClubsServlet.BODY_ERROR);
+  }
+
+  @Test
+  public void doGet_failVerification() throws IOException {
+    listClubsServlet = new ListClubsServlet(nullVerifier, memberHandler);
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(VALID_JSON_MEMBER)));
+
+    listClubsServlet.doGet(request, response);
+
+    verify(response).sendError(
+        HttpServletResponse.SC_FORBIDDEN,
+        AuthenticationHelper.INVALID_ID_TOKEN_ERROR);
+  }
+}

--- a/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
@@ -14,12 +14,12 @@
 
 package com.google.coffeehouse.servlets;
 
+import static com.google.coffeehouse.common.MembershipConstants.MembershipStatus;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
-import static com.google.coffeehouse.common.MembershipConstants.MembershipStatus;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
@@ -27,7 +27,6 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Book;
 import com.google.coffeehouse.common.Club;
-import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;
@@ -94,7 +93,7 @@ public class ListClubsServletTest {
              + ListClubsServlet.NOT_MEMBER + "\"",
       "}");
   private static final String SYNTACTICALLY_INCORRECT_JSON =
-      "{\"" + Person.USER_ID_FIELD_NAME + "\"";
+      "{\"" + UpdateClubServlet.ID_TOKEN_FIELD_NAME + "\"";
 
   private ListClubsServlet listClubsServlet;
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();


### PR DESCRIPTION
Takes in an ID token and a string that says if we are looking for clubs we are a member of, or clubs we are not a member of. Responds with a list of the clubs that fit this criteria. Currently, there is no pagination for this servlet, that is something that should be added when we have the time and need.