### PR TITLE
Update /api/update-person to take ID token rather than user ID.

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
@@ -98,10 +98,10 @@ public class UpdatePersonServlet extends HttpServlet {
   /** 
    * Updates a Person object in the database and returns that object in JSON format.
    * @param request the POST request that must have a valid JSON representation of the Person to be
-   *     updated, a {@code "idToken"} key that corresponds to the OpenID ID token of the user
+   *     updated, an {@code "idToken"} key that corresponds to the OpenID ID token of the user
    *     who wants to update their Person, as well as an optional mask of fields that will be
    *     updated as its body. The Person to be updated must be represnted by a {@code "person"}
-   *     key, who's value is an object that represents the updated Person. The update mask must
+   *     key, whose value is an object that represents the updated Person. The update mask must
    *     have the key {@code "updateMask"} and the value of a comma separated list of the fields to
    *     be updated from the "person" key. If no update mask exists, all fields from the "person"
    *     key will be used to update the Person. If the request does not have a "person" key,

--- a/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
@@ -14,11 +14,19 @@
 
 package com.google.coffeehouse.servlets;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
+import com.google.coffeehouse.util.AuthenticationHelper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +35,10 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/** 
+ * Servlet to update a {@link Person} from Http POST Request Body (in JSON format),
+ * save it in database, and return it in JSON format.
+ */
 @WebServlet("/api/update-person")
 public class UpdatePersonServlet extends HttpServlet {
   /** The fields of the Person object that can be updated. */
@@ -40,6 +52,8 @@ public class UpdatePersonServlet extends HttpServlet {
   /** Message to be logged when the body of the POST request cannot be parsed. */
   public static final String LOG_BODY_ERROR_MESSAGE =
       "Body unable to be parsed in UpdatePersonServlet: ";
+  /** Message to be logged when an invalid ID token is passed in. */
+  public static final String LOG_SECURITY_MESSAGE = "Forbidden action attempted: ";
   /** 
    * The error string sent by the response object in doPost when the body of the 
    * POST request does not have a required field.
@@ -52,17 +66,24 @@ public class UpdatePersonServlet extends HttpServlet {
   public static final String PERSON_FIELD_NAME = "person";
   /** Name of the key in the input JSON that corresponds to the update mask. */
   public static final String UPDATE_MASK_FIELD_NAME = "updateMask";
+  /** Name of the key in the input JSON that corresponds to the ID token. */
+  public static final String ID_TOKEN_FIELD_NAME = "idToken";
 
   private static final Gson gson = new Gson();
-  private static StorageHandlerApi storageHandler;
+  private static final HttpTransport transport = new NetHttpTransport();
+  private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+  private final GoogleIdTokenVerifier verifier;
+  private final StorageHandlerApi storageHandler;
 
   /** 
    * Overloaded constructor for dependency injection.
+   * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Person
    */
-  public UpdatePersonServlet(StorageHandlerApi storageHandler) {
+  public UpdatePersonServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
+    this.verifier = verifier;
   }
 
   /** 
@@ -71,21 +92,27 @@ public class UpdatePersonServlet extends HttpServlet {
   public UpdatePersonServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
+    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
   }
 
   /** 
    * Updates a Person object in the database and returns that object in JSON format.
    * @param request the POST request that must have a valid JSON representation of the Person to be
-   *     updated as well as an optional mask of fields that will be updated as its body. The
-   *     Person to be updated must be represnted by a {@code "person"} key, who's value is an 
-   *     object that represents the updated Person. The update mask must have the key
-   *     {@code "updateMask"} and the value of a comma separated list of the fields to be updated
-   *     from the "person" key. If no update mask exists, all fields from the "person" key will be
-   *     used to update the Person. If the request does not have either of these keys, or is
-   *     syntactically incorrect, the response object will send a "400 Bad Request error"
+   *     updated, a {@code "idToken"} key that corresponds to the OpenID ID token of the user
+   *     who wants to update their Person, as well as an optional mask of fields that will be
+   *     updated as its body. The Person to be updated must be represnted by a {@code "person"}
+   *     key, who's value is an object that represents the updated Person. The update mask must
+   *     have the key {@code "updateMask"} and the value of a comma separated list of the fields to
+   *     be updated from the "person" key. If no update mask exists, all fields from the "person"
+   *     key will be used to update the Person. If the request does not have a "person" key,
+   *     or is syntactically incorrect, the response object will send a "400 Bad Request error". If
+   *     the request does not have an "idToken" key or has an invalid ID token associated with that
+   *     key, the response object will send a "403 Forbidden error"
    * @param response the response from this method, will contain the updated Person in JSON format.
-   *     If the request object does not have a valid JSON body (as described in the request
-   *     parameter) this object will send a "400 Bad Request error"
+   *     If the request object does not have a valid "person" key (or is syntactically incorrect)
+   *     this object will send a "400 Bad Request error". If the request does not have an "idToken"
+   *     key or has an invalid ID token associated with that key, the response object will send a
+   *     "403 Forbidden error"
    * @throws IOException if an input or output error is detected when the servlet handles the request
    */
   @Override
@@ -101,11 +128,9 @@ public class UpdatePersonServlet extends HttpServlet {
       String rawUpdateMask = (String) mappedRequest.getOrDefault(UPDATE_MASK_FIELD_NAME, null);
 
       // Get the Person from the database and convert it to JSON for easy manipulation.
-      String userId = (String) personInfo.getOrDefault(Person.USER_ID_FIELD_NAME, null);
-      if (userId == null) {
-        throw new IllegalArgumentException(
-            String.format(NO_FIELD_ERROR, Person.USER_ID_FIELD_NAME));
-      }
+      String idToken = (String) mappedRequest.get(ID_TOKEN_FIELD_NAME);
+      String userId = AuthenticationHelper.getUserIdFromIdToken(idToken, verifier);
+
       personToUpdate = storageHandler.fetchPersonFromId(userId);
       JsonObject personToUpdateJson = gson.toJsonTree(personToUpdate).getAsJsonObject();
 
@@ -123,6 +148,10 @@ public class UpdatePersonServlet extends HttpServlet {
     } catch (IllegalArgumentException e) {
       System.out.println(LOG_INPUT_ERROR_MESSAGE + e.getMessage());
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+      return;
+    } catch (GeneralSecurityException e) {
+      System.out.println(LOG_SECURITY_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
       return;
     } catch (Exception e) {
       System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());

--- a/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
@@ -20,15 +20,20 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Matchers.*;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.common.Person;
+import com.google.coffeehouse.storagehandler.StorageHandlerApi;
+import com.google.coffeehouse.util.AuthenticationHelper;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.security.GeneralSecurityException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.After;
@@ -48,6 +53,7 @@ public class UpdatePersonServletTest {
   private static final String ALT_EMAIL = "New Email";
   private static final String PRONOUNS = "Old Pronouns";
   private static final String ALT_PRONOUNS = "New Pronouns";
+  private static final String ID_TOKEN = "Identification Token";
   private static final Person testPerson = Person.newBuilder()
                                                  .setNickname(NICKNAME)
                                                  .setEmail(EMAIL)
@@ -56,6 +62,7 @@ public class UpdatePersonServletTest {
                                                  .build();
   private static final String MASK_PARTIAL_UPDATE = String.join("\n",
       "{",
+      "  \"" + UpdatePersonServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
       "  \"" + UpdatePersonServlet.UPDATE_MASK_FIELD_NAME + "\" : \"" +
       Person.NICKNAME_FIELD_NAME + "," + Person.PRONOUNS_FIELD_NAME + "\",",
       "  \"" + UpdatePersonServlet.PERSON_FIELD_NAME + "\" : {",
@@ -67,6 +74,7 @@ public class UpdatePersonServletTest {
       "}");
   private static final String NO_MASK_UPDATE = String.join("\n",
       "{",
+      "  \"" + UpdatePersonServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
       "  \"" + UpdatePersonServlet.PERSON_FIELD_NAME + "\" : {",
       "    \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + ALT_NICKNAME + "\",",
       "    \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + ALT_EMAIL + "\",",
@@ -76,6 +84,7 @@ public class UpdatePersonServletTest {
       "}");
   private static final String MASK_ALL_UPDATE = String.join("\n",
       "{",
+      "  \"" + UpdatePersonServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
       "  \"" + UpdatePersonServlet.UPDATE_MASK_FIELD_NAME + "\" : \"" +
       Person.NICKNAME_FIELD_NAME + "," + Person.PRONOUNS_FIELD_NAME + "," +
       Person.EMAIL_FIELD_NAME + "," + Person.USER_ID_FIELD_NAME + "\",",
@@ -86,7 +95,7 @@ public class UpdatePersonServletTest {
       "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + ALT_USER_ID + "\"",
       "  }",
       "}");
-  private static final String NO_USER_ID = String.join("\n",
+  private static final String NO_ID_TOKEN = String.join("\n",
       "{",
       "  \"" + UpdatePersonServlet.UPDATE_MASK_FIELD_NAME + "\" : \"" +
       Person.NICKNAME_FIELD_NAME + "," + Person.PRONOUNS_FIELD_NAME + "," +
@@ -99,6 +108,7 @@ public class UpdatePersonServletTest {
       "}");
   private static final String NO_PERSON = String.join("\n",
       "{",
+      "  \"" + UpdatePersonServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
       "  \"" + UpdatePersonServlet.UPDATE_MASK_FIELD_NAME + "\" : \"" +
       Person.NICKNAME_FIELD_NAME + "," + Person.PRONOUNS_FIELD_NAME + "," +
       Person.EMAIL_FIELD_NAME + "," + Person.USER_ID_FIELD_NAME + "\"",
@@ -106,24 +116,43 @@ public class UpdatePersonServletTest {
   private static final String SYNTACTICALLY_INCORRECT_JSON = "{\"{";
 
   private UpdatePersonServlet updatePersonServlet;
+  private UpdatePersonServlet failingUpdatePersonServlet;
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
   private StringWriter stringWriter = new StringWriter();
 
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi handler;
+  @Mock private GoogleIdTokenVerifier verifier;
+  @Mock private GoogleIdTokenVerifier nullVerifier;
+  @Mock private GoogleIdToken idToken;
+  @Mock private Payload payload;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws IOException, GeneralSecurityException {
     helper.setUp();
 
     handler = mock(StorageHandlerApi.class);
     when(handler.fetchPersonFromId(anyString())).thenReturn(testPerson);
-    updatePersonServlet = new UpdatePersonServlet(handler);
 
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+
+    // Verification setup that successfully verifies and gives correct userId.
+    payload = mock(Payload.class);
+    when(payload.getSubject()).thenReturn(USER_ID);
+    idToken = mock(GoogleIdToken.class);
+    when(idToken.getPayload()).thenReturn(payload);
+    verifier = mock(GoogleIdTokenVerifier.class);
+    when(verifier.verify(anyString())).thenReturn(idToken);
+
+    // Verification setup that does not successfully verify.
+    nullVerifier = mock(GoogleIdTokenVerifier.class);
+    when(nullVerifier.verify(anyString())).thenReturn(null);
+
+    updatePersonServlet = new UpdatePersonServlet(verifier, handler);
+    failingUpdatePersonServlet = new UpdatePersonServlet(nullVerifier, handler);
   }
 
   @After
@@ -182,12 +211,11 @@ public class UpdatePersonServletTest {
   @Test
   public void doPost_noUserId() throws IOException {
     when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(NO_USER_ID)));
+          new BufferedReader(new StringReader(NO_ID_TOKEN)));
     updatePersonServlet.doPost(request, response);
     
     verify(response).sendError(
-        HttpServletResponse.SC_BAD_REQUEST,
-        String.format(updatePersonServlet.NO_FIELD_ERROR, Person.USER_ID_FIELD_NAME));
+        HttpServletResponse.SC_FORBIDDEN, AuthenticationHelper.INVALID_ID_TOKEN_ERROR);
   }
 
   @Test
@@ -209,5 +237,14 @@ public class UpdatePersonServletTest {
     
     verify(response).sendError(
         HttpServletResponse.SC_BAD_REQUEST, updatePersonServlet.BODY_ERROR);
+  }
+
+  @Test
+  public void doPost_failedVerification() throws IOException {
+    when(request.getReader()).thenReturn(
+        new BufferedReader(new StringReader(MASK_ALL_UPDATE)));
+    failingUpdatePersonServlet.doPost(request, response);
+    verify(response).sendError(
+        HttpServletResponse.SC_FORBIDDEN, AuthenticationHelper.INVALID_ID_TOKEN_ERROR);
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
@@ -69,7 +69,7 @@ public class UpdatePersonServletTest {
       "    \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + ALT_NICKNAME + "\",",
       "    \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + ALT_EMAIL + "\",",
       "    \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + ALT_PRONOUNS + "\",",
-      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + ALT_USER_ID + "\"",
+      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "  }",
       "}");
   private static final String NO_MASK_UPDATE = String.join("\n",
@@ -79,7 +79,7 @@ public class UpdatePersonServletTest {
       "    \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + ALT_NICKNAME + "\",",
       "    \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + ALT_EMAIL + "\",",
       "    \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + ALT_PRONOUNS + "\",",
-      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + ALT_USER_ID + "\"",
+      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "  }",
       "}");
   private static final String MASK_ALL_UPDATE = String.join("\n",
@@ -92,7 +92,7 @@ public class UpdatePersonServletTest {
       "    \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + ALT_NICKNAME + "\",",
       "    \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + ALT_EMAIL + "\",",
       "    \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + ALT_PRONOUNS + "\",",
-      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + ALT_USER_ID + "\"",
+      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + USER_ID + "\"",
       "  }",
       "}");
   private static final String NO_ID_TOKEN = String.join("\n",
@@ -114,6 +114,18 @@ public class UpdatePersonServletTest {
       Person.EMAIL_FIELD_NAME + "," + Person.USER_ID_FIELD_NAME + "\"",
       "}");
   private static final String SYNTACTICALLY_INCORRECT_JSON = "{\"{";
+  private static final String ID_MISMATCH_JSON = String.join("\n",
+      "{",
+      "  \"" + UpdatePersonServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\",",
+      "  \"" + UpdatePersonServlet.UPDATE_MASK_FIELD_NAME + "\" : \"" +
+      Person.NICKNAME_FIELD_NAME + "," + Person.PRONOUNS_FIELD_NAME + "\",",
+      "  \"" + UpdatePersonServlet.PERSON_FIELD_NAME + "\" : {",
+      "    \"" + Person.NICKNAME_FIELD_NAME + "\" : \"" + ALT_NICKNAME + "\",",
+      "    \"" + Person.EMAIL_FIELD_NAME + "\" : \"" + ALT_EMAIL + "\",",
+      "    \"" + Person.PRONOUNS_FIELD_NAME + "\" : \"" + ALT_PRONOUNS + "\",",
+      "    \"" + Person.USER_ID_FIELD_NAME + "\" : \"" + ALT_USER_ID + "\"",
+      "  }",
+      "}");
 
   private UpdatePersonServlet updatePersonServlet;
   private UpdatePersonServlet failingUpdatePersonServlet;
@@ -246,5 +258,15 @@ public class UpdatePersonServletTest {
     failingUpdatePersonServlet.doPost(request, response);
     verify(response).sendError(
         HttpServletResponse.SC_FORBIDDEN, AuthenticationHelper.INVALID_ID_TOKEN_ERROR);
+  }
+
+  @Test
+  public void doPost_userIdMismatch() throws IOException {
+    when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader(ID_MISMATCH_JSON)));
+    updatePersonServlet.doPost(request, response);
+    
+    verify(response).sendError(
+        HttpServletResponse.SC_BAD_REQUEST, updatePersonServlet.LOG_USER_ID_MISMATCH);
   }
 }


### PR DESCRIPTION
Previously, update-person determined which Person to update by looking at a passed in user ID. This is unsafe, and thus it has been refactored to look at an OpenID ID token instead (which can be verified to not be forged).