### PR TITLE
Create functionality for adding ownership to a club in the Storage Handler

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -148,17 +148,19 @@ public class StorageHandler {
   }
 
   /**
-  * Runs a transaction that adds a membership to the database.
+  * Runs a transaction that adds a membership or ownership to the database.
   * This method checks if a person is already a member of a club by calling a helper function.
   * If the person does not exist, this method will buffer a single mutation that adds
-  * the membership. Otherwise, it will throw an exception indicating that the person
+  * the membership (or owner). Otherwise, it will throw an exception indicating that the person
   * is already a member of the club.
   *
-  * @param  dbClient    the database client
-  * @param  userId      the user ID string used to perform the transaction
-  * @param  clubId      the club ID string used to perform the transaction
+  * @param  dbClient             the database client
+  * @param  userId               the user ID string used to perform the transaction
+  * @param  clubId               the club ID string used to perform the transaction
+  * @param  membershipLevel      the integer representing membership level (member or owner)
   */
-  public static void runAddMembershipTransaction(DatabaseClient dbClient, String userId, String clubId) {
+  public static void runAddMembershipOrOwnershipTransaction(DatabaseClient dbClient, String userId,
+                                                            String clubId, int membershipLevel) {
     dbClient
         .readWriteTransaction()
         .run(
@@ -167,7 +169,9 @@ public class StorageHandler {
             public Void run(TransactionContext transaction) throws Exception {
               Boolean exists = StorageHandlerHelper.checkMembership(transaction, userId, clubId);
               if (!exists) {
-                transaction.buffer(StorageHandlerCommonMutations.addMembershipMutation(userId, clubId));
+                transaction.buffer(
+                  StorageHandlerCommonMutations.addMembershipOrOwnershipMutation(
+                    userId, clubId, membershipLevel));
               } else {
                 throw new IllegalArgumentException(MembershipConstants.PERSON_ALREADY_IN_CLUB);
               }
@@ -178,7 +182,7 @@ public class StorageHandler {
   }
 
   /**
-  * Runs a transaction that deletes a membership from the database.
+  * Runs a transaction that deletes a membership (or ownership) from the database.
   * This method checks if a person is already a member of a club by calling a helper function.
   * If the person does exist, this method will buffer a single mutation that deletes the
   * membership. Otherwise, it will throw an exception indicating that the person is

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -159,7 +159,7 @@ public class StorageHandler {
   * @param  clubId               the club ID string used to perform the transaction
   * @param  membershipLevel      the integer representing membership level (member or owner)
   */
-  public static void runAddMembershipOrOwnershipTransaction(DatabaseClient dbClient, String userId,
+  public static void runAddAnyMembershipTypeTransaction(DatabaseClient dbClient, String userId,
                                                             String clubId, int membershipLevel) {
     dbClient
         .readWriteTransaction()
@@ -167,10 +167,10 @@ public class StorageHandler {
           new TransactionCallable<Void>() {
             @Override
             public Void run(TransactionContext transaction) throws Exception {
-              Boolean exists = StorageHandlerHelper.checkMembership(transaction, userId, clubId);
+              Boolean exists = StorageHandlerHelper.checkAnyMembership(transaction, userId, clubId);
               if (!exists) {
                 transaction.buffer(
-                  StorageHandlerCommonMutations.addMembershipOrOwnershipMutation(
+                  StorageHandlerCommonMutations.addAnyMembershipTypeMutation(
                     userId, clubId, membershipLevel));
               } else {
                 throw new IllegalArgumentException(MembershipConstants.PERSON_ALREADY_IN_CLUB);
@@ -199,7 +199,7 @@ public class StorageHandler {
           new TransactionCallable<Void>() {
             @Override
             public Void run(TransactionContext transaction) throws Exception {
-              Boolean exists = StorageHandlerHelper.checkMembership(transaction, userId, clubId);
+              Boolean exists = StorageHandlerHelper.checkAnyMembership(transaction, userId, clubId);
               if (exists) {
                 transaction.buffer(StorageHandlerCommonMutations.deleteMembershipMutation(userId, clubId));
               } else {

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -152,7 +152,9 @@ public class StorageHandler {
   * This method checks if a person is already a member of a club by calling a helper function.
   * If the person does not exist, this method will buffer a single mutation that adds
   * the membership (or owner). Otherwise, it will throw an exception indicating that the person
-  * is already a member of the club.
+  * is already a member of the club. If a person is already a member of a club, and is trying to
+  * become an owner, it will throw an RuntimeException because only one unique key of
+  * (userId, clubId) can exist in the database Memberships table at a time. 
   *
   * @param  dbClient             the database client
   * @param  userId               the user ID string used to perform the transaction

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerApi.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerApi.java
@@ -64,14 +64,28 @@ public class StorageHandlerApi {
 
   /**
   * Adds a membership to the database.
-  * This method calls a transacation that adds a membership to the table.
+  * This method calls a transacation that adds a membership to the Memberships table.
   *
   * @param  userId      the user ID string specifying the person who is being added as a member
   * @param  clubId      the club ID string specifying the club a person is being added to
   */
   public void addMembership(String userId, String clubId) {
-    StorageHandler.runAddMembershipTransaction(dbClient, userId, clubId);
+    StorageHandler.runAddMembershipOrOwnershipTransaction(
+      dbClient, userId, clubId, MembershipConstants.MEMBER);
   }
+
+  /**
+  * Adds an ownership to the database.
+  * This method calls a transacation that adds an ownership to the Memberships table.
+  *
+  * @param  userId      the user ID string specifying the person who is being added as a member
+  * @param  clubId      the club ID string specifying the club a person is being added to
+  */
+  public void addOwnership(String userId, String clubId) {
+    StorageHandler.runAddMembershipOrOwnershipTransaction(
+      dbClient, userId, clubId, MembershipConstants.OWNER);
+  }
+
 
   /**
   * Deletes a membership from the database.

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerApi.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerApi.java
@@ -70,7 +70,7 @@ public class StorageHandlerApi {
   * @param  clubId      the club ID string specifying the club a person is being added to
   */
   public void addMembership(String userId, String clubId) {
-    StorageHandler.runAddMembershipOrOwnershipTransaction(
+    StorageHandler.runAddAnyMembershipTypeTransaction(
       dbClient, userId, clubId, MembershipConstants.MEMBER);
   }
 
@@ -82,7 +82,7 @@ public class StorageHandlerApi {
   * @param  clubId      the club ID string specifying the club a person is being added to
   */
   public void addOwnership(String userId, String clubId) {
-    StorageHandler.runAddMembershipOrOwnershipTransaction(
+    StorageHandler.runAddAnyMembershipTypeTransaction(
       dbClient, userId, clubId, MembershipConstants.OWNER);
   }
 

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerCommonMutations.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerCommonMutations.java
@@ -26,27 +26,29 @@ import com.google.cloud.spanner.Value;
 */
 public class StorageHandlerCommonMutations {
   /**
-  * Returns a single Mutation that can add a membership to the database.
+  * Returns a single Mutation that can add a membership or ownership to the database.
   *
-  * @param  userId      the user ID string used to insert the membership into the table
-  * @param  clubId      the club ID string used to insert the membership into the table
-  * @return             the single mutation to add a membership
+  * @param  userId               the user ID string used to insert the membership into the table
+  * @param  clubId               the club ID string used to insert the membership into the table
+  * @param  membershipLevel      the integer representing membership level (member or owner)
+  * @return                      the single mutation to add a membership
   */
-  public static Mutation addMembershipMutation(String userId, String clubId) {
+  public static Mutation addMembershipOrOwnershipMutation(String userId, String clubId,
+                                                          int membershipLevel) {
     return Mutation.newInsertBuilder("Memberships")
                    .set("userId")
                    .to(userId)
                    .set("clubId")
                    .to(clubId)
                    .set("membershipType")
-                   .to(MembershipConstants.MEMBER)
+                   .to(membershipLevel)
                    .set("timestamp")
                    .to(Value.COMMIT_TIMESTAMP)
                    .build();
   }
 
   /**
-  * Returns a single Mutation that can delete a membership from the database.
+  * Returns a single Mutation that can delete a membership (ow ownership) from the database.
   *
   * @param  userId      the user ID string used to query the membership table
   * @param  clubId      the club ID string used to query the membership table

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerCommonMutations.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerCommonMutations.java
@@ -33,7 +33,7 @@ public class StorageHandlerCommonMutations {
   * @param  membershipLevel      the integer representing membership level (member or owner)
   * @return                      the single mutation to add a membership
   */
-  public static Mutation addMembershipOrOwnershipMutation(String userId, String clubId,
+  public static Mutation addAnyMembershipTypeMutation(String userId, String clubId,
                                                           int membershipLevel) {
     return Mutation.newInsertBuilder("Memberships")
                    .set("userId")

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
@@ -69,7 +69,7 @@ public class StorageHandlerHelper {
               "Memberships",
               Key.of(userId, clubId),
               Arrays.asList("membershipType"));
-    return ((row != null) && (row.getLong(/** index = **/0) == MembershipConstants.OWNER));
+    return ((row != null) && (row.getLong(/** index= **/0) == MembershipConstants.OWNER));
   }
 
   /**

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
@@ -19,6 +19,7 @@ import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
+import com.google.coffeehouse.common.MembershipConstants;
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,7 +30,7 @@ import java.util.List;
 public class StorageHandlerHelper {
 
   /**
-  * Returns a Boolean that indicates whether or not a person is a member of a club.
+  * Returns a Boolean that indicates whether or not a person is in a club (member or owner).
   * This method creates a Struct that holds a single row from a database read row transacation.
   * It returns false if the Struct is null, indicating the membership does not exist.
   * It returns true if the Struct is not null, indicating the membership does exist.
@@ -47,6 +48,28 @@ public class StorageHandlerHelper {
               Key.of(userId, clubId),
               Arrays.asList("userId"));
     return (row != null) ? true : false;
+  }
+
+  /**
+  * Returns a Boolean that indicates whether or not a person is the owner of a club.
+  * This method creates a Struct that holds a single row from a database read row transacation.
+  * It returns false if the Struct is null, indicating the membership does not exist.
+  * It returns true if the Struct is not null, indicating the membership does exist.
+  *
+  * @param  readContext  the context for an attempt to perform a transaction
+  * @param  userId       the user ID string of the user we are checking is in a club
+  * @param  clubId       the club ID string of the club we are checking the user is in
+  * @return              the Boolean true or false representing if the membership exists or not
+  */
+  public static Boolean checkOwnership(ReadContext readContext, String userId, String clubId) {
+    Struct row =
+          readContext
+            .readRow(
+              "Memberships",
+              Key.of(userId, clubId),
+              Arrays.asList("membershipType"));
+    return ((row != null) && (row.getLong(/** index = **/0) == MembershipConstants.OWNER))
+            ? true : false;
   }
 
   /**

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
@@ -31,7 +31,7 @@ public class StorageHandlerHelper {
 
   /**
   * Returns a Boolean that indicates whether or not a person is in a club (member or owner).
-  * This method creates a Struct that holds a single row from a database read row transacation.
+  * This method creates a Struct that holds a single row from a database read row transaction.
   * It returns false if the Struct is null, indicating the membership does not exist.
   * It returns true if the Struct is not null, indicating the membership does exist.
   *
@@ -54,7 +54,8 @@ public class StorageHandlerHelper {
   * Returns a Boolean that indicates whether or not a person is the owner of a club.
   * This method creates a Struct that holds a single row from a database read row transacation.
   * It returns false if the Struct is null, indicating the membership does not exist.
-  * It returns true if the Struct is not null, indicating the membership does exist.
+  * It returns true if the Struct is not null (indicating that the membership does exist), and that
+  * the membership is of type OWNER.
   *
   * @param  readContext  the context for an attempt to perform a transaction
   * @param  userId       the user ID string of the user we are checking is in a club

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
@@ -40,14 +40,14 @@ public class StorageHandlerHelper {
   * @param  clubId       the club ID string of the club we are checking the user is in
   * @return              the Boolean true or false representing if the membership exists or not
   */
-  public static Boolean checkMembership(ReadContext readContext, String userId, String clubId) {
+  public static Boolean checkAnyMembership(ReadContext readContext, String userId, String clubId) {
     Struct row =
           readContext
             .readRow(
               "Memberships",
               Key.of(userId, clubId),
               Arrays.asList("userId"));
-    return (row != null) ? true : false;
+    return (row != null);
   }
 
   /**
@@ -68,8 +68,7 @@ public class StorageHandlerHelper {
               "Memberships",
               Key.of(userId, clubId),
               Arrays.asList("membershipType"));
-    return ((row != null) && (row.getLong(/** index = **/0) == MembershipConstants.OWNER))
-            ? true : false;
+    return ((row != null) && (row.getLong(/** index = **/0) == MembershipConstants.OWNER));
   }
 
   /**

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -46,6 +46,16 @@ public class StorageHandlerHelperTest {
   }
 
   @Test
+  public void checkAnyMembership_memberFailsToBecomeOwner() throws Exception {
+    StorageHandlerTestHelper.insertPerson("person");
+    StorageHandlerTestHelper.insertClubWithContentWarnings("club");
+    StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
+    assertThrows(RuntimeException.class, () -> {
+      StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.OWNER);;
+    });
+  }
+
+  @Test
   public void checkAnyMembership_personInClub() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
     StorageHandlerTestHelper.insertClub("club");

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -46,20 +46,20 @@ public class StorageHandlerHelperTest {
   }
 
   @Test
-  public void checkMembership_personInClub() throws Exception {
+  public void checkAnyMembership_personInClub() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
     StorageHandlerTestHelper.insertClub("club");
     StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
     ReadContext readContext = dbClient.singleUse();
-    Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");
+    Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");
     assertTrue(actual);
   }
 
   @Test
-  public void checkMembership_personNotInClub() throws Exception {
+  public void checkAnyMembership_personNotInClub() throws Exception {
     StorageHandlerTestHelper.insertClub("club");
     ReadContext readContext = dbClient.singleUse();
-    Boolean actual = StorageHandlerHelper.checkMembership(readContext, "personNotInClub", "club");
+    Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "personNotInClub", "club");
     assertFalse(actual);
   }
 

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.ReadContext;
+import com.google.coffeehouse.common.MembershipConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,9 +48,20 @@ public class StorageHandlerTest {
   }
 
   @Test
-  public void getAddMembershipTransaction() throws Exception {
+  public void runAddMembershipOrOwnershipTransaction_member() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
-    StorageHandler.runAddMembershipTransaction(dbClient, "person", "club");
+    StorageHandler.runAddMembershipOrOwnershipTransaction(
+      dbClient, "person", "club", MembershipConstants.MEMBER);
+    ReadContext readContext = dbClient.singleUse();
+    Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");
+    assertTrue(actual);
+  }
+
+  @Test
+  public void runAddMembershipOrOwnershipTransaction_owner() throws Exception {
+    StorageHandlerTestHelper.insertPerson("person");
+    StorageHandler.runAddMembershipOrOwnershipTransaction(
+      dbClient, "person", "club", MembershipConstants.OWNER);
     ReadContext readContext = dbClient.singleUse();
     Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");
     assertTrue(actual);
@@ -58,7 +70,7 @@ public class StorageHandlerTest {
   @Test
   public void getDeleteMembershipTransaction() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
-    StorageHandlerTestHelper.insertMembership("person", "club");
+    StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
     StorageHandler.runDeleteMembershipTransaction(dbClient, "person", "club");
     ReadContext readContext = dbClient.singleUse();
     Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -63,7 +63,7 @@ public class StorageHandlerTest {
     StorageHandler.runAddAnyMembershipTypeTransaction(
       dbClient, "person", "club", MembershipConstants.OWNER);
     ReadContext readContext = dbClient.singleUse();
-    Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");
+    Boolean actual = StorageHandlerHelper.checkOwnership(readContext, "person", "club");
     assertTrue(actual);
   }
 

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -48,22 +48,22 @@ public class StorageHandlerTest {
   }
 
   @Test
-  public void runAddMembershipOrOwnershipTransaction_member() throws Exception {
+  public void runAddAnyMembershipTypeTransaction_member() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
-    StorageHandler.runAddMembershipOrOwnershipTransaction(
+    StorageHandler.runAddAnyMembershipTypeTransaction(
       dbClient, "person", "club", MembershipConstants.MEMBER);
     ReadContext readContext = dbClient.singleUse();
-    Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");
+    Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");
     assertTrue(actual);
   }
 
   @Test
-  public void runAddMembershipOrOwnershipTransaction_owner() throws Exception {
+  public void runAddAnyMembershipTypeTransaction_owner() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
-    StorageHandler.runAddMembershipOrOwnershipTransaction(
+    StorageHandler.runAddAnyMembershipTypeTransaction(
       dbClient, "person", "club", MembershipConstants.OWNER);
     ReadContext readContext = dbClient.singleUse();
-    Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");
+    Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");
     assertTrue(actual);
   }
 
@@ -73,7 +73,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
     StorageHandler.runDeleteMembershipTransaction(dbClient, "person", "club");
     ReadContext readContext = dbClient.singleUse();
-    Boolean actual = StorageHandlerHelper.checkMembership(readContext, "person", "club");
+    Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");
     assertFalse(actual);
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTestHelper.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTestHelper.java
@@ -88,7 +88,7 @@ public class StorageHandlerTestHelper {
     dbClient.write(mutations);
   }
 
-  public static void insertMembership(String person_id, String club_id) {
+  public static void insertMembership(String person_id, String club_id, int membershipLevel) {
     List<Mutation> mutations = new ArrayList<>();
     mutations.add(
       Mutation.newInsertBuilder("Memberships")
@@ -97,7 +97,7 @@ public class StorageHandlerTestHelper {
         .set("clubId")
         .to(club_id)
         .set("membershipType")
-        .to(MembershipConstants.MEMBER)
+        .to(membershipLevel)
         .set("timestamp")
         .to(Value.COMMIT_TIMESTAMP)
         .build());


### PR DESCRIPTION
Refactor `addMembershipMutation(userId, clubId)` method in StorageHandlerCommonMutations.java to be `addMembershipOrOwnershipMutation(userId, clubId, membershipLevel)`.
Refactor `runAddOwnershipTransaction(dbClient, userId, clubId)` method in StorageHandler.java to be `runAddMembershipOrOwnershipTransaction(dbClient, userId, clubId, membershipLevel)`.
Create new `addOwnership(userId, clubId)` method in StorageHandlerApi.java to add an ownership to the database. This method is a wrapper call to `runAddMembershipOrOwnershipTransaction(dbClient, userId, clubId, membershipType)` with the membershipType parameter set to `MembershipConstants.OWNER`.

Adding ownership to a club would be called in the CreateClubServlet #16 in order to handle the TODO comment ("Once membership table is implemented, create a membership for the person who made Club"). Closes #61 .