### PR TITLE
Replace body in GET requests with URL parameters. 

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -34,37 +34,23 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Servlet to get a {@link Person} from Http GET Request Body (in JSON format)
+ * Servlet to get a {@link Person} from Http GET Request URL parameters
  * that exists in the database through a call to the Storage Handler API,
  * and return it in JSON format.
  */
 @WebServlet("/api/get-profile")
 public class GetProfileServlet extends HttpServlet {
-
-  /**
-   * The error string sent by the response object in doGet when the body of the 
-   * GET request cannot be used to fetch a {@link Person} for any reason.
-   */
-  public static final String BODY_ERROR = "- unable to parse body.";
-
-  /** The logged error string when an error parsing the body of the GET request is encountered. */
-  public static final String LOG_BODY_ERROR_MESSAGE = 
-      "Body unable to be parsed in GetProfileServlet: ";
-
-  /** Message to be logged when an invalid ID token is passed in. */
-  public static final String LOG_SECURITY_MESSAGE =
-      "Forbidden action attempted: ";
-
-  /**
-   * The error string sent by the response object in doGet when the body of the 
-   * GET request does not have a required field.
-   */
-  public static final String NO_FIELD_ERROR = "Missing \"%s\" field in JSON";
-  /** Message to be logged when the body of the GET request does not have required fields. */
+  /** Message to be logged when the GET request does not have a required URL parameter. */
+  public static final String NO_FIELD_ERROR = "No \"%s\" parameter found.";
+  /** Message to be logged when a non-security related exception is thrown in the servlet. */
   public static final String LOG_INPUT_ERROR_MESSAGE =
-      "Error with JSON input in GetProfileServlet: ";
+      "Exception encountered in GetProfileServlet: ";
+  /**
+   * Message to be logged when an invalid ID token is passed in or a no ID token is passed in.
+   */
+  public static final String LOG_SECURITY_MESSAGE = "Forbidden action attempted: ";
   /** Name of the key in the input JSON that corresponds to the ID token. */
-  public static final String ID_TOKEN_FIELD_NAME = "idToken";
+  public static final String ID_TOKEN_PARAMETER = "idToken";
 
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
@@ -94,38 +80,34 @@ public class GetProfileServlet extends HttpServlet {
   
   /** 
    * Returns a {@link Person} object in JSON format from information in the database.
-   * @param request the GET request that must have a valid JSON representation of the
-   *     {@code "idToken"} of the user to be passed in order to fetch a person from ID in the
-   *     database.  If the required "idToken" field doesn't exist, the response object will
-   *     send a "400 Bad Request error". If the person's userdId with the idToken passed in does
-   *     not exist, the response object will send a "404 Not Found error". If the JSON
-   *     body is not valid, and unable to be parsed, the response object will send a
-   *     "500 Internal Server error". If the user does not have a valid ID token, the
-   *     response object will send a "403 Forbidden error"
+   * @param request the GET request that must have a {@code "idToken"} URL parameter corresponding
+   *     to the user's OpenID ID token. If the required "idToken" parameter doesn't exist, the
+   *     response object will send a "400 Bad Request error". If the person's userdId (extracted
+   *     from the ID token) does not exist in the database, the response object will send a
+   *     "404 Not Found error". If the user does not have a valid ID token, the response object
+   *     will send a "403 Forbidden error"
    * @param response the response from this method, will contain the object in JSON format.
-   *     If the request object has a valid JSON body without the required field "idToken", the
-   *     response will send a "400 Bad Request error". If the request object is attempting to get a
-   *     profile which does not exist in the database, the response will send a
-   *     "404 Not Found error". If the request object is unable to be parsed, the response will
-   *     send a "500 Internal Server error". If the user does not have a valid ID token, the
-   *     response object will send a "403 Forbidden error"
+   *     If the required "idToken" parameter from the request doesn't exist, this object will send
+   *     a "400 Bad Request error". If the person's userdId (extracted from the ID token) does not
+   *     exist in the database, this object will send a "404 Not Found error". If the user does not
+   *     have a valid ID token, this object will send a "403 Forbidden error"
    * @throws IOException if an input or output error is detected when the servlet handles the request
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Person person;
     try {
-      Map userInfo = gson.fromJson(request.getReader(), Map.class);
-      String idToken = (String) userInfo.get(ID_TOKEN_FIELD_NAME);
+      String idToken = request.getParameter(ID_TOKEN_PARAMETER);
       if (idToken == null) {
-        throw new IllegalArgumentException(String.format(NO_FIELD_ERROR, ID_TOKEN_FIELD_NAME));
+        throw new IllegalArgumentException(String.format(NO_FIELD_ERROR, ID_TOKEN_PARAMETER));
       }
       String userId = AuthenticationHelper.getUserIdFromIdToken(idToken, verifier);
-      if (userId == null) {
-        throw new IllegalArgumentException(String.format(NO_FIELD_ERROR, Person.USER_ID_FIELD_NAME));
-      }
       person = storageHandler.fetchPersonFromId(userId);
-    } catch (IllegalArgumentException e) {
+    } catch (GeneralSecurityException e) {
+      System.out.println(LOG_SECURITY_MESSAGE + e.getMessage());
+      response.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
+      return;
+    } catch (Exception e) {
       System.out.println(LOG_INPUT_ERROR_MESSAGE + e.getMessage());
       if (e.getMessage() == StorageHandler.PERSON_DOES_NOT_EXIST) {
         response.sendError(HttpServletResponse.SC_NOT_FOUND,
@@ -133,14 +115,6 @@ public class GetProfileServlet extends HttpServlet {
       } else {
         response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
       }
-      return;
-    } catch (GeneralSecurityException e) {
-      System.out.println(LOG_SECURITY_MESSAGE + e.getMessage());
-      response.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
-      return;
-    } catch (Exception e) {
-      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, BODY_ERROR);
       return;
     }
     response.setContentType("application/json;");

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -27,7 +27,6 @@ import com.google.coffeehouse.util.AuthenticationHelper;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
@@ -21,7 +21,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.coffeehouse.common.Club;
-import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;

--- a/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
@@ -28,7 +28,6 @@ import com.google.coffeehouse.util.AuthenticationHelper;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Map;
 import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -44,35 +43,28 @@ import javax.servlet.http.HttpServletResponse;
  */
 @WebServlet("/api/list-clubs")
 public class ListClubsServlet extends HttpServlet {
-  /**
-   * The error string sent by the response object in doGet when the body of the 
-   * GET request cannot be be parsed.
-   */
-  public static final String BODY_ERROR = "- unable to parse body.";
-  /** The logged error string when an error parsing the body of the GET request is encountered. */
-  public static final String LOG_BODY_ERROR_MESSAGE =
-      "Body unable to be parsed in ListClubsServlet: ";
-  /** Message to be logged when the body of the GET request does not have required fields. */
-  public static final String LOG_INPUT_ERROR_MESSAGE =
-      "Error with JSON input in ListClubsServlet: No \"%s\" found in JSON.";
+  /** Message to be logged when the GET request does not have a required URL parameter. */
+  public static final String LOG_INPUT_ERROR_MESSAGE = "No \"%s\" parameter found.";
   /**
    * Message to be logged when an invalid ID token is passed in or a no ID token is passed in.
    */
   public static final String LOG_SECURITY_MESSAGE = "Forbidden action attempted: ";
-  /** Name of the key in the input JSON that corresponds to the ID token. */
-  public static final String ID_TOKEN_FIELD_NAME = "idToken";
+  /** Message to be logged when a non-security related exception is thrown in the servlet. */
+  public static final String GENERAL_LOG_ERROR = "Exception encountered in ListClubsServlet: ";
+  /** Name of the URL parameter that corresponds to the ID token. */
+  public static final String ID_TOKEN_PARAMETER = "idToken";
   /**
-   * Name of the key in the input JSON that corresponds to if we are searching for clubs the user
+   * Name of the URL parameter that corresponds to if we are searching for clubs the user
    * is a member of, or clubs that the user is not a member of.
    */
-  public static final String MEMBERSHIP_STATUS_FIELD_NAME = "membershipStatus";
+  public static final String MEMBERSHIP_STATUS_PARAMETER = "membershipStatus";
   /**
-   * A possible value for the MEMBERSHIP_STATUS_FIELD_NAME key that means we are searching for
+   * A possible value for the MEMBERSHIP_STATUS_PARAMETER that means we are searching for
    * clubs that the user is a member of.
    */
   public static final String MEMBER = "member";
   /**
-   * A possible value for the MEMBERSHIP_STATUS_FIELD_NAME key that means we are searching for
+   * A possible value for the MEMBERSHIP_STATUS_PARAMETER that means we are searching for
    * clubs that the user is not a member of.
    */
   public static final String NOT_MEMBER = "not member";
@@ -105,20 +97,17 @@ public class ListClubsServlet extends HttpServlet {
 
   /**
    * Responds with a JSON list of {@link Club} objects that a user is either a member of or not.
-   * @param request the GET request that must have the {@code "idToken"} of the user who wants
-   *     a list of clubs that they are in (or not in) back. It must also have a
-   *     {@code "membershipStatus"} key which is mapped to either "member" or "not member". This
-   *     key determines if we return a list of clubs where the user is a member, or not a member.
-   *     If the required "membershipStatus" field does not exist, the response object
-   *     will send a "400 Bad Request error". If the JSON body is not valid, and unable to be
-   *     parsed, the response object will send a "500 Internal Server error". If the "idToken"
-   *     field is missing or invalid, the response object will send a "403 Forbidden error"
+   * @param request the GET request that must have a {@code "idToken"} URL parameter corresponding
+   *     to the user's OpenID ID token. The request must also have a {@code "membershipStatus"}
+   *     URL parameter, which is mapped to either "member" or "not member". This key determines if
+   *     we return a list of clubs where the user is a member, or not a member. If the required
+   *     "membershipStatus" parameter does not exist, the response object will send a
+   *     "400 Bad Request error". If the "idToken" parameter is missing or invalid, the response
+   *     object will send a "403 Forbidden error"
    * @param response the response from this method, will contain the list of Clubs in JSON format.
-   *     If the required "membershipStatus" field does not exist in the request
-   *     object, this object will send a "400 Bad Request error". If the JSON body is not valid,
-   *     and unable to be parsed, this object will send a "500 Internal Server error". If the
-   *     "idToken" field is missing or invalid, the response object will send a
-   *     "403 Forbidden error"
+   *     If the required "membershipStatus" parameter does not exist, this object will send a
+   *     "400 Bad Request error". If the "idToken" parameter is missing or invalid, this object
+   *     will send a "403 Forbidden error"
    * @throws IOException if an input or output error is detected when the servlet handles the request
    */
   @Override
@@ -126,14 +115,13 @@ public class ListClubsServlet extends HttpServlet {
     List<Club> clubs;
     try {
       // Get the userId after validating the user's ID token.
-      Map requestInfo = gson.fromJson(request.getReader(), Map.class);
-      String idToken = (String) requestInfo.get(ID_TOKEN_FIELD_NAME);
+      String idToken = request.getParameter(ID_TOKEN_PARAMETER);
       String userId = AuthenticationHelper.getUserIdFromIdToken(idToken, verifier);
 
-      String status = (String) requestInfo.get(MEMBERSHIP_STATUS_FIELD_NAME);
+      String status = request.getParameter(MEMBERSHIP_STATUS_PARAMETER);
       if (status == null || !(status.equals(MEMBER) || status.equals(NOT_MEMBER))) {
         throw new IllegalArgumentException(
-            String.format(LOG_INPUT_ERROR_MESSAGE, MEMBERSHIP_STATUS_FIELD_NAME));
+            String.format(LOG_INPUT_ERROR_MESSAGE, MEMBERSHIP_STATUS_PARAMETER));
       }
 
       MembershipStatus membershipStatus = status.equals(MEMBER)
@@ -141,17 +129,13 @@ public class ListClubsServlet extends HttpServlet {
           : MembershipStatus.NOT_MEMBER;
       
       clubs = storageHandler.listClubsFromUserId(userId, membershipStatus);
-    } catch (IllegalArgumentException e) {
-      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-      return;
     } catch (GeneralSecurityException e) {
       System.out.println(LOG_SECURITY_MESSAGE + e.getMessage());
       response.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
       return;
     } catch (Exception e) {
-      System.out.println(LOG_BODY_ERROR_MESSAGE + e.getMessage());
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, BODY_ERROR);
+      System.out.println(GENERAL_LOG_ERROR + e.getMessage());
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
       return;
     }
     response.setContentType("application/json;");

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -56,18 +56,6 @@ public class GetProfileServletTest {
   private static final String NICKNAME = "test";
   private static final String PRONOUNS = "they";
   private static final String ID_TOKEN = "Identification Token";
-  private static final String JSON = String.join("\n",
-      "{",
-      "  \"" + GetProfileServlet.ID_TOKEN_FIELD_NAME + "\" : \"" + ID_TOKEN + "\"",
-      "}");
-  private static final String NO_ID_TOKEN_JSON = "{}";
-  private static final String PROFILE_NOT_FOUND_JSON = String.join("\n",
-      "{",
-      "  \"" + GetProfileServlet.ID_TOKEN_FIELD_NAME + "\" : \"\"",
-      "}");
-  private static final String SYNTACTICALLY_INCORRECT_JSON =
-      "{\"" + GetProfileServlet.ID_TOKEN_FIELD_NAME + "\"";
-
   private Person testPerson = Person.newBuilder()
                                     .setEmail(EMAIL)
                                     .setNickname(NICKNAME)
@@ -124,8 +112,8 @@ public class GetProfileServletTest {
 
   @Test
   public void doGet_validInput() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(JSON)));
+    when(request.getParameter(eq(GetProfileServlet.ID_TOKEN_PARAMETER)))
+        .thenReturn(ID_TOKEN);
     getProfileServlet = new GetProfileServlet(correctVerifier, successfulHandler);
 
     getProfileServlet.doGet(request, response);
@@ -142,20 +130,20 @@ public class GetProfileServletTest {
 
   @Test
   public void doGet_noIdToken() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(NO_ID_TOKEN_JSON)));
+    when(request.getParameter(eq(GetProfileServlet.ID_TOKEN_PARAMETER)))
+        .thenReturn(null);
     getProfileServlet = new GetProfileServlet(correctVerifier, successfulHandler);
     getProfileServlet.doGet(request, response);
     
     verify(response).sendError(
         HttpServletResponse.SC_BAD_REQUEST,
-        String.format(getProfileServlet.NO_FIELD_ERROR, getProfileServlet.ID_TOKEN_FIELD_NAME));
+        String.format(getProfileServlet.NO_FIELD_ERROR, getProfileServlet.ID_TOKEN_PARAMETER));
   }
 
   @Test
   public void doGet_noProfileFound() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(PROFILE_NOT_FOUND_JSON)));
+    when(request.getParameter(eq(GetProfileServlet.ID_TOKEN_PARAMETER)))
+        .thenReturn(ID_TOKEN);
     failingGetProfileServlet = new GetProfileServlet(correctVerifier, failingHandler);
     failingGetProfileServlet.doGet(request, response);
     
@@ -165,21 +153,9 @@ public class GetProfileServletTest {
   }
 
   @Test
-  public void doGet_syntacticallyIncorrectInput() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(SYNTACTICALLY_INCORRECT_JSON)));
-    getProfileServlet = new GetProfileServlet(correctVerifier, successfulHandler);
-    getProfileServlet.doGet(request, response);
-    
-    verify(response).sendError(
-        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-        GetProfileServlet.BODY_ERROR);
-  }
-
-  @Test
   public void doGet_failVerification() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(JSON)));
+    when(request.getParameter(eq(GetProfileServlet.ID_TOKEN_PARAMETER)))
+        .thenReturn(ID_TOKEN);
     getProfileServlet = new GetProfileServlet(nullVerifier, successfulHandler);
     getProfileServlet.doGet(request, response);
 


### PR DESCRIPTION
Previously our servlets depended on information in the body of GET requests. A GET request should not have a body (https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET), and thus we have replaced our usage of the body with just URL parameters. This has the added benefit of simplifying the code.