### PR TITLE
Implement user ability to view club.

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import AppBar from "./appbar/AppBar";
 import { BrowserRouter, Redirect, Route, Switch } from "react-router-dom";
 import clsx from "clsx";
+import { Club } from "./pages/club/Club";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { defaultServices } from "./contexts/default_services";
 import Drawer from "./drawer/Drawer";
@@ -78,10 +79,11 @@ function UserLoggedIn(props: UserLoggedInProps) {
         />
         <main>
           <Switch>
+            <Route exact path={PageConstants.URL_YOUR_CLUBS} component={YourClubs} />
             <Route exact path={PageConstants.URL_EXPLORE} component={Explore} />
             <Route exact path={PageConstants.URL_PROFILE} component={Profile} />
-            <Route exact path={PageConstants.URL_YOUR_CLUBS} component={YourClubs} />
             <Redirect to={PageConstants.URL_YOUR_CLUBS} />
+            <Route path={PageConstants.URL_CLUB} component={Club} />
           </Switch>
         </main>
       </ServiceContext.Provider>

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -80,10 +80,10 @@ function UserLoggedIn(props: UserLoggedInProps) {
         <main>
           <Switch>
             <Route exact path={PageConstants.URL_YOUR_CLUBS} component={YourClubs} />
+            <Route path={PageConstants.URL_CLUB} component={Club} />
             <Route exact path={PageConstants.URL_EXPLORE} component={Explore} />
             <Route exact path={PageConstants.URL_PROFILE} component={Profile} />
             <Redirect to={PageConstants.URL_YOUR_CLUBS} />
-            <Route path={PageConstants.URL_CLUB} component={Club} />
           </Switch>
         </main>
       </ServiceContext.Provider>

--- a/frontend/src/components/pages/club/Club.tsx
+++ b/frontend/src/components/pages/club/Club.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 /**
- * Displays information for viewing a club.
+ * Displays information of a club that the user is a member of.
  */
 export const Club = (props) => {
   const classes = useStyles();

--- a/frontend/src/components/pages/club/Club.tsx
+++ b/frontend/src/components/pages/club/Club.tsx
@@ -1,13 +1,62 @@
 import * as React from "react";
+import { BookInfo } from "../club_display/BookInfo";
+import Box from "@material-ui/core/Box";
+import { ClubDescription } from "../club_display/ClubDescription";
+import { ContentWarnings } from "../club_display/ContentWarnings";
 import { ClubInterface } from "../../../services/backend_service_interface/backend_service_interface";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    club: {
+      width: "1500px",
+    },
+    clubContainer: {
+      alignItems: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      flexShrink: 3,
+      marginTop: theme.spacing(12),
+    },
+    contentContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      marginBottom: theme.spacing(2),
+      marginLeft: theme.spacing(3),
+      marginRight: theme.spacing(3),
+      marginTop: theme.spacing(2),
+    },
+    infoAndWarnings: {
+      display: 'flex',
+      marginBottom: theme.spacing(2),
+      marginTop: theme.spacing(1),
+    },
+  }),
+);
+
+/**
+ * Displays information for viewing a club.
+ */
 export const Club = (props) => {
+  const classes = useStyles();
+
   const [handle, setHandle] = React.useState<string>(props.match.params.handle);
   const [club, setClub] = React.useState<ClubInterface>(props.location.state.club);
 
   return (
-    <div>
-      <p style={{marginTop: "100px"}}>{handle}</p>
+    <div className={classes.clubContainer}>
+      <div className={classes.club}>
+        <Box border={1} borderColor="text.primary" borderRadius={16}>
+          <div className={classes.contentContainer}>
+            <h1>{handle}</h1>
+            <ClubDescription description={club.description} />
+            <div className={classes.infoAndWarnings}>
+              <BookInfo book={club.currentBook} />
+              <ContentWarnings contentWarnings={club.contentWarnings} />
+            </div>
+          </div>
+        </Box>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/pages/club/Club.tsx
+++ b/frontend/src/components/pages/club/Club.tsx
@@ -1,10 +1,13 @@
-import * as React from 'react';
+import * as React from "react";
+import { ClubInterface } from "../../../services/backend_service_interface/backend_service_interface";
 
-export const Club = () => {
+export const Club = (props) => {
+  const [handle, setHandle] = React.useState<string>(props.match.params.handle);
+  const [club, setClub] = React.useState<ClubInterface>(props.location.state.club);
+
   return (
     <div>
-      <h2>Club</h2>
-      <p>This is the Club page.</p>
+      <p style={{marginTop: "100px"}}>{handle}</p>
     </div>
   );
 }

--- a/frontend/src/components/pages/club/Club.tsx
+++ b/frontend/src/components/pages/club/Club.tsx
@@ -40,19 +40,16 @@ const useStyles = makeStyles((theme: Theme) =>
 export const Club = (props) => {
   const classes = useStyles();
 
-  const [handle, setHandle] = React.useState<string>(props.match.params.handle);
-  const [club, setClub] = React.useState<ClubInterface>(props.location.state.club);
-
   return (
     <div className={classes.clubContainer}>
       <div className={classes.club}>
         <Box border={1} borderColor="text.primary" borderRadius={16}>
           <div className={classes.contentContainer}>
-            <h1>{handle}</h1>
-            <ClubDescription description={club.description} />
+            <h1>{props.match.params.handle}</h1>
+            <ClubDescription description={props.location.state.club.description} />
             <div className={classes.infoAndWarnings}>
-              <BookInfo book={club.currentBook} />
-              <ContentWarnings contentWarnings={club.contentWarnings} />
+              <BookInfo book={props.location.state.club.currentBook} />
+              <ContentWarnings contentWarnings={props.location.state.club.contentWarnings} />
             </div>
           </div>
         </Box>

--- a/frontend/src/components/pages/club_display/BookInfo.tsx
+++ b/frontend/src/components/pages/club_display/BookInfo.tsx
@@ -24,7 +24,7 @@ export const BookInfo = (props: BookInfoProps) => {
   const classes = useStyles();
 
   return (
-    <div>
+    <>
       <div className={classes.boldTextElement}>
         Current Book:
       </div>
@@ -32,6 +32,6 @@ export const BookInfo = (props: BookInfoProps) => {
         <div>{props.book.title}</div>
         <div>by {props.book.author}</div>
       </p>
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/pages/club_display/BookInfo.tsx
+++ b/frontend/src/components/pages/club_display/BookInfo.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface BookInfoProps {
   book: BookInterface;
-};
+}
 
 /** Displays the title and author of the club's current book. */
 export const BookInfo = (props: BookInfoProps) => {

--- a/frontend/src/components/pages/club_display/BookInfo.tsx
+++ b/frontend/src/components/pages/club_display/BookInfo.tsx
@@ -24,7 +24,7 @@ export const BookInfo = (props: BookInfoProps) => {
   const classes = useStyles();
 
   return (
-    <>
+    <div>
       <div className={classes.boldTextElement}>
         Current Book:
       </div>
@@ -32,6 +32,6 @@ export const BookInfo = (props: BookInfoProps) => {
         <div>{props.book.title}</div>
         <div>by {props.book.author}</div>
       </p>
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/pages/club_display/BookInfo.tsx
+++ b/frontend/src/components/pages/club_display/BookInfo.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { BookInterface } from "../../../services/backend_service_interface/backend_service_interface";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    boldTextElement: {
+      fontWeight: 'bold',
+      marginBottom: theme.spacing(0),
+    },
+    textElement: {
+      marginBottom: theme.spacing(0),
+      marginTop: theme.spacing(0),
+    },
+  })
+);
+
+interface BookInfoProps {
+  book: BookInterface;
+};
+
+/** Displays the title and author of the club's current book. */
+export const BookInfo = (props: BookInfoProps) => {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <div className={classes.boldTextElement}>
+        Current Book:
+      </div>
+      <p className={classes.textElement}>
+        <div>{props.book.title}</div>
+        <div>by {props.book.author}</div>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/pages/club_display/ClubDescription.tsx
+++ b/frontend/src/components/pages/club_display/ClubDescription.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    boldTextElement: {
+      fontWeight: 'bold',
+      marginBottom: theme.spacing(0),
+    },
+    textElement: {
+      marginBottom: theme.spacing(0),
+      marginTop: theme.spacing(0),
+    },
+  })
+);
+
+interface ClubDescriptionProps {
+  description: string,
+};
+
+/** Displays the club's description. */
+export const ClubDescription = (props: ClubDescriptionProps) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <div className={classes.boldTextElement}>
+        Description:
+      </div>
+      <p className={classes.textElement}>
+        {props.description}
+      </p>
+    </>
+  );
+}

--- a/frontend/src/components/pages/club_display/ClubDescription.tsx
+++ b/frontend/src/components/pages/club_display/ClubDescription.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface ClubDescriptionProps {
   description: string,
-};
+}
 
 /** Displays the club's description. */
 export const ClubDescription = (props: ClubDescriptionProps) => {

--- a/frontend/src/components/pages/club_display/ContentWarnings.tsx
+++ b/frontend/src/components/pages/club_display/ContentWarnings.tsx
@@ -28,14 +28,14 @@ export const ContentWarnings = (props: ContentWarningsProps) => {
 
   if (contentWarnings) {
     return (
-        <div>
+        <>
           <ul className={classes.warningsList}>
             <div className={classes.warningsHeader}>Content Warnings:</div>
             {contentWarnings.map((item, index) => (
               <li>{item}</li>
             ))}
           </ul>
-        </div>
+        </>
     );
   } else {
     return (

--- a/frontend/src/components/pages/club_display/ContentWarnings.tsx
+++ b/frontend/src/components/pages/club_display/ContentWarnings.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    warningsHeader: {
+      fontWeight: 'bold',
+      marginBottom: theme.spacing(0),
+      marginLeft: '-17px',
+    },
+    warningsList: {
+      fontWeight: 'bold',
+      justifyContent: 'left',
+      marginBottom: theme.spacing(0),
+      marginTop: theme.spacing(0),
+    },
+  }),
+);
+
+interface ContentWarningsProps {
+  contentWarnings: string[],
+}
+
+/** Displays content warnings associated with the club's current book. */
+export const ContentWarnings = (props: ContentWarningsProps) => {
+  const classes = useStyles();
+  const contentWarnings = props.contentWarnings;
+
+  if (contentWarnings) {
+    return (
+        <div>
+          <ul className={classes.warningsList}>
+            <div className={classes.warningsHeader}>Content Warnings:</div>
+            {contentWarnings.map((item, index) => (
+              <li>{item}</li>
+            ))}
+          </ul>
+        </div>
+    );
+  } else {
+    return (
+      <p className={classes.warningsList}>
+        No Content Warnings
+      </p>
+    );
+  }
+}

--- a/frontend/src/components/pages/page_constants.ts
+++ b/frontend/src/components/pages/page_constants.ts
@@ -1,4 +1,5 @@
-export const URL_EXPLORE = "/Explore";
 export const URL_LOGIN = "/Login";
-export const URL_PROFILE = "/Profile";
 export const URL_YOUR_CLUBS = "/YourClubs";
+export const URL_CLUB = "/Club/:handle";
+export const URL_EXPLORE = "/Explore";
+export const URL_PROFILE = "/Profile";

--- a/frontend/src/components/pages/your_clubs/ClubList.tsx
+++ b/frontend/src/components/pages/your_clubs/ClubList.tsx
@@ -13,7 +13,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import HighlightOffIcon from "@material-ui/icons/HighlightOff";
-import { Link } from "react-router-dom"
+import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import PageviewIcon from "@material-ui/icons/Pageview";
 import { Theme } from "@material-ui/core/styles";
@@ -55,7 +55,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     link: {
       color: theme.palette.text.primary,
-      textDecoration: 'none'
+      textDecoration: 'none',
     },
     listedClubsContainer: {
       alignItems: 'center',

--- a/frontend/src/components/pages/your_clubs/ClubList.tsx
+++ b/frontend/src/components/pages/your_clubs/ClubList.tsx
@@ -10,6 +10,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import HighlightOffIcon from "@material-ui/icons/HighlightOff";
+import { Link } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles";
 import PageviewIcon from "@material-ui/icons/Pageview";
 import { Theme } from "@material-ui/core/styles";
@@ -52,6 +53,10 @@ const useStyles = makeStyles((theme: Theme) =>
     clubTitle: {
       marginBottom: theme.spacing(0),
       maxWidth: '500px',
+    },
+    link: {
+      color: theme.palette.text.primary,
+      textDecoration: 'none'
     },
     listedClubsContainer: {
       alignItems: 'center',
@@ -120,14 +125,22 @@ export function ClubList(props: ClubListProps) {
                 <div className={classes.clubHeader}>
                   <h2 className={classes.clubTitle}>{item.name}</h2>
                   <div className={classes.buttonContainer}>
-                    <Button
-                      className={classes.button}
-                      color="primary"
-                      endIcon={<PageviewIcon />}
-                      variant="contained"
+                    <Link to={{
+                      pathname:'/Club/' + item.name,
+                      state: {club: item}
+                      }}
+                      className={classes.link}
+                      key={item.name}
                     >
-                      View Club
-                    </Button>
+                      <Button
+                        className={classes.button}
+                        color="primary"
+                        endIcon={<PageviewIcon />}
+                        variant="contained"
+                      >
+                        View Club
+                      </Button>
+                    </Link>
                     {item.ownerId !== props.userId ? (
                       <Button
                         className={classes.button}

--- a/frontend/src/components/pages/your_clubs/ClubList.tsx
+++ b/frontend/src/components/pages/your_clubs/ClubList.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
+import { BookInfo } from "../club_display/BookInfo";
 import { BookInterface } from "../../../services/backend_service_interface/backend_service_interface";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
+import { ClubDescription } from "../club_display/ClubDescription";
 import { ClubInterface } from "../../../services/backend_service_interface/backend_service_interface";
+import { ContentWarnings } from "../club_display/ContentWarnings";
 import { createStyles } from "@material-ui/core/styles";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -17,10 +20,6 @@ import { Theme } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    boldTextElement: {
-      fontWeight: 'bold',
-      marginBottom: theme.spacing(0),
-    },
     button : {
       marginLeft: theme.spacing(1),
       marginTop: theme.spacing(1),
@@ -63,21 +62,6 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
       marginBottom: theme.spacing(3),
-    },
-    textElement: {
-      marginBottom: theme.spacing(0),
-      marginTop: theme.spacing(0),
-    },
-    warningsHeader: {
-      fontWeight: 'bold',
-      marginBottom: theme.spacing(0),
-      marginLeft: '-17px',
-    },
-    warningsList: {
-      fontWeight: 'bold',
-      justifyContent: 'left',
-      marginBottom: theme.spacing(0),
-      marginTop: theme.spacing(0),
     },
   }),
 );
@@ -179,72 +163,6 @@ export function ClubList(props: ClubListProps) {
     );
   } else {
     return (<div></div>);
-  }
-}
-
-interface ClubDescriptionProps {
-  description: string,
-};
-
-/** Displays the club's description. */
-function ClubDescription(props: ClubDescriptionProps) {
-  const classes = useStyles();
-
-  return (
-    <>
-      <div className={classes.boldTextElement}>
-        Description:
-      </div>
-      <p className={classes.textElement}>
-        {props.description}
-      </p>
-    </>
-  );
-}
-
-interface BookInfoProps {
-  book: BookInterface;
-};
-
-/** Displays the title and author of the club's current book. */
-function BookInfo(props: BookInfoProps) {
-  const classes = useStyles();
-
-  return (
-    <div>
-      <div className={classes.boldTextElement}>
-        Current Book:
-      </div>
-      <p className={classes.textElement}>
-        <div>{props.book.title}</div>
-        <div>by {props.book.author}</div>
-      </p>
-    </div>
-  );
-}
-
-/** Displays content warnings associated with the club's current book. */
-function ContentWarnings(props) {
-  const classes = useStyles();
-  const contentWarnings = props.contentWarnings;
-
-  if (contentWarnings) {
-    return (
-        <div>
-          <ul className={classes.warningsList}>
-            <div className={classes.warningsHeader}>Content Warnings:</div>
-            {contentWarnings.map((item, index) => (
-              <li>{item}</li>
-            ))}
-          </ul>
-        </div>
-    );
-  } else {
-    return (
-      <p className={classes.warningsList}>
-        No Content Warnings
-      </p>
-    );
   }
 }
 


### PR DESCRIPTION
View club button that has previously appeared on club cards on the /YourClubs page now links the user to a separate page where the club content is displayed. While currently the information that appears on both is the same, clubs will eventually list club owner and members.

Screenshots:
ViewClub button: https://screenshot.googleplex.com/96roL8oYDfD.png
ViewClub page: https://screenshot.googleplex.com/2uYPyYLwZ1o.png

Additionally, while it can't be seen in SnipIts, the URL that is redirected to is /Club/:handle.