### PR TITLE
Implement /Explore Page

### DIFF
--- a/frontend/src/components/pages/club_display/NumClubsToDisplay.tsx
+++ b/frontend/src/components/pages/club_display/NumClubsToDisplay.tsx
@@ -20,9 +20,9 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface NumClubsToDisplayProps {
   handleNumClubsChange(event: React.ChangeEvent<HTMLInputElement>): void;
-  numClubsDisplayed: number;
-  showClubsMemberOf: boolean;
-};
+  numClubsDisplayed: number,
+  showClubsMemberOf: boolean,
+}
 
 /** Displays the title and author of the club's current book. */
 export const NumClubsToDisplay = (props: NumClubsToDisplayProps) => {

--- a/frontend/src/components/pages/club_display/NumClubsToDisplay.tsx
+++ b/frontend/src/components/pages/club_display/NumClubsToDisplay.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import { DEFAULT_NUM_DISPLAYED } from "../club_display/club_display_consts";
+import FormControl from "@material-ui/core/FormControl";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    formControl: {
+      margin: theme.spacing(1),
+      marginBottom: theme.spacing(2),
+      marginRight: theme.spacing(8),
+      minWidth: 120,
+    },
+  }),
+);
+
+interface NumClubsToDisplayProps {
+  handleNumClubsChange(event: React.ChangeEvent<HTMLInputElement>): void;
+  numClubsDisplayed: number;
+  showClubsMemberOf: boolean;
+};
+
+/** Displays the title and author of the club's current book. */
+export const NumClubsToDisplay = (props: NumClubsToDisplayProps) => {
+  const classes = useStyles();
+
+  return (
+    <FormControl className={classes.formControl}>
+      <InputLabel id="number-of-displayed-clubs-label">
+        Number of Displayed Clubs
+      </InputLabel>
+      <Select
+        labelId="number-of-displayed-clubs-label"
+        id="number-of-displayed-clubs"
+        value={props.numClubsDisplayed ? props.numClubsDisplayed : DEFAULT_NUM_DISPLAYED}
+        onChange={props.handleNumClubsChange}
+        label="Number of Clubs to Display"
+      >
+        <MenuItem value={10}>10</MenuItem>
+        <MenuItem value={25}>25</MenuItem>
+        <MenuItem value={50}>50</MenuItem>
+        <MenuItem value={100}>100</MenuItem>
+      </Select>
+      <FormHelperText>
+        {props.showClubsMemberOf
+          ? "The number of clubs of which you are a member to be displayed."
+          : "The number of public clubs you would like to be displayed."
+        }
+      </FormHelperText>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/pages/club_display/club_display_consts.ts
+++ b/frontend/src/components/pages/club_display/club_display_consts.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_NUM_DISPLAYED = 10;

--- a/frontend/src/components/pages/explore/Explore.tsx
+++ b/frontend/src/components/pages/explore/Explore.tsx
@@ -5,6 +5,7 @@ import { ClubInterface } from "../../../services/backend_service_interface/backe
 import { ContentWarnings } from "../club_display/ContentWarnings";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import { DEFAULT_NUM_DISPLAYED } from "../club_display/club_display_consts";
+import { ExploreClubList} from "./ExploreClubList";
 import { NumClubsToDisplay } from "../club_display/NumClubsToDisplay";
 import { ServiceContext } from "../../contexts/contexts";
 
@@ -22,12 +23,6 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: theme.spacing(0),
       marginTop: theme.spacing(1),
       maxHeight: '50px',
-    },
-    formControl: {
-      margin: theme.spacing(1),
-      marginBottom: theme.spacing(2),
-      marginRight: theme.spacing(8),
-      minWidth: 120,
     },
     topUtilitiesContainer: {
       display: 'flex',
@@ -67,6 +62,14 @@ export const Explore = () => {
     setNumClubsDisplayed(Number(event.target.value));
   }
 
+  const updateClubListAfterJoining = async (clubId: string) => {
+    const success:boolean = await yourClubsHandlerService.joinClub(
+        clubId, loginStatusHandlerService.getUserToken());
+    if (success) {
+      updateClubList();
+    }
+  }
+
   return (
     <div className={classes.root}>
       <div className={classes.topUtilitiesContainer}>
@@ -76,6 +79,10 @@ export const Explore = () => {
           showClubsMemberOf={false}
         />
       </div>
+      <ExploreClubList
+        clubsToDisplay={listedClubs}
+        handleJoinClub={updateClubListAfterJoining}
+      />
     </div>
   );
 }

--- a/frontend/src/components/pages/explore/Explore.tsx
+++ b/frontend/src/components/pages/explore/Explore.tsx
@@ -1,10 +1,81 @@
-import * as React from 'react';
+import * as React from "react";
+import { BookInfo } from "../club_display/BookInfo";
+import { ClubDescription } from "../club_display/ClubDescription";
+import { ClubInterface } from "../../../services/backend_service_interface/backend_service_interface";
+import { ContentWarnings } from "../club_display/ContentWarnings";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import { DEFAULT_NUM_DISPLAYED } from "../club_display/club_display_consts";
+import { NumClubsToDisplay } from "../club_display/NumClubsToDisplay";
+import { ServiceContext } from "../../contexts/contexts";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      flexWrap: 'wrap',
+      marginTop: theme.spacing(12),
+      marginLeft: theme.spacing(4),
+    },
+    button : {
+      margin: theme.spacing(1),
+      marginLeft: theme.spacing(0),
+      marginTop: theme.spacing(1),
+      maxHeight: '50px',
+    },
+    formControl: {
+      margin: theme.spacing(1),
+      marginBottom: theme.spacing(2),
+      marginRight: theme.spacing(8),
+      minWidth: 120,
+    },
+    topUtilitiesContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+    },
+  }),
+);
 
 export const Explore = () => {
+  const classes = useStyles();
+
+  const contextServices = React.useContext(ServiceContext);
+  const yourClubsHandlerService = contextServices.yourClubsHandlerService;
+  const loginStatusHandlerService = contextServices.loginStatusHandlerService;
+
+  const [listedClubs, setListedClubs] = React.useState<ClubInterface[]|undefined>(undefined);
+  const [numClubsDisplayed, setNumClubsDisplayed] = React.useState<number|undefined>(DEFAULT_NUM_DISPLAYED);
+
+  /* Re-renders Explore page only when number of displayed clubs changes. */
+  React.useEffect(() => {
+    (async() => {
+      const numClubsToDisplay = numClubsDisplayed
+        ? setNumClubsDisplayed(numClubsDisplayed)
+        : setNumClubsDisplayed(DEFAULT_NUM_DISPLAYED)
+      updateClubList();
+    })();
+  }, [numClubsDisplayed]);
+
+  const updateClubList = async () => {
+    const listedClubsPromise =
+      await yourClubsHandlerService.listClubs(
+          loginStatusHandlerService.getUserToken(), "not member");
+    setListedClubs(listedClubsPromise);
+  }
+
+  const handleNumClubsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setNumClubsDisplayed(Number(event.target.value));
+  }
+
   return (
-    <div>
-      <h2>Explore</h2>
-      <p>This is the Explore page.</p>
+    <div className={classes.root}>
+      <div className={classes.topUtilitiesContainer}>
+        <NumClubsToDisplay
+          handleNumClubsChange={handleNumClubsChange}
+          numClubsDisplayed={numClubsDisplayed}
+          showClubsMemberOf={false}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/pages/explore/ExploreClubList.tsx
+++ b/frontend/src/components/pages/explore/ExploreClubList.tsx
@@ -156,7 +156,7 @@ export function ExploreClubList(props: ExploreClubListProps) {
       </div>
     );
   } else {
-    return (<div></div>);
+    return (<></>);
   }
 }
 

--- a/frontend/src/components/pages/explore/ExploreClubList.tsx
+++ b/frontend/src/components/pages/explore/ExploreClubList.tsx
@@ -55,7 +55,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     link: {
       color: theme.palette.text.primary,
-      textDecoration: 'none'
+      textDecoration: 'none',
     },
     listedClubsContainer: {
       alignItems: 'center',

--- a/frontend/src/components/pages/explore/ExploreClubList.tsx
+++ b/frontend/src/components/pages/explore/ExploreClubList.tsx
@@ -13,7 +13,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import InputIcon from "@material-ui/icons/Input";
-import { Link } from "react-router-dom"
+import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import PageviewIcon from "@material-ui/icons/Pageview";
 import { Theme } from "@material-ui/core/styles";
@@ -79,7 +79,7 @@ export function ExploreClubList(props: ExploreClubListProps) {
   const classes = useStyles();
   const clubsToDisplay = props.clubsToDisplay;
 
-  const [joinClubAlertOpen, setJoinAlertOpen] = React.useState<boolean>(/* closed */ false);
+  const [joinClubAlertOpen, setJoinAlertOpen] = React.useState<boolean>(/* closed= */ false);
   const [nameOfClubAlert, setNameofClubAlert] = React.useState<string|undefined>(undefined);
 
   const openAlertWindow = (clubId: string) => {
@@ -108,8 +108,8 @@ export function ExploreClubList(props: ExploreClubListProps) {
                   <h2 className={classes.clubTitle}>{item.name}</h2>
                   <div className={classes.buttonContainer}>
                     <Link to={{
-                      pathname:'/Club/' + item.name,
-                      state: {club: item}
+                        pathname: '/Club/' + item.name,
+                        state: {club: item}
                       }}
                       className={classes.link}
                       key={item.name}

--- a/frontend/src/components/pages/explore/ExploreClubList.tsx
+++ b/frontend/src/components/pages/explore/ExploreClubList.tsx
@@ -1,0 +1,203 @@
+import * as React from "react";
+import { BookInfo } from "../club_display/BookInfo";
+import { BookInterface } from "../../../services/backend_service_interface/backend_service_interface";
+import Box from "@material-ui/core/Box";
+import Button from "@material-ui/core/Button";
+import { ClubDescription } from "../club_display/ClubDescription";
+import { ClubInterface } from "../../../services/backend_service_interface/backend_service_interface";
+import { ContentWarnings } from "../club_display/ContentWarnings";
+import { createStyles } from "@material-ui/core/styles";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import HighlightOffIcon from "@material-ui/icons/HighlightOff";
+import { Link } from "react-router-dom"
+import { makeStyles } from "@material-ui/core/styles";
+import PageviewIcon from "@material-ui/icons/Pageview";
+import { ServiceContext } from "../../contexts/contexts";
+import { Theme } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    button : {
+      marginLeft: theme.spacing(1),
+      marginTop: theme.spacing(1),
+      height: '35px',
+    },
+    buttonContainer: {
+      marginTop: theme.spacing(1),
+    },
+    club : {
+      marginTop: theme.spacing(3),
+      width: '900px',
+    },
+    clubContent: {
+      display: 'flex',
+      flexBasis: '100%',
+      flexWrap: 'wrap',
+      marginBottom: theme.spacing(2),
+      marginLeft: theme.spacing(2),
+      marginRight: theme.spacing(2),
+    },
+    clubHeader: {
+      display: 'flex',
+      flexBasis: '100%',
+      justifyContent: 'space-between',
+      marginBottom: theme.spacing(2),
+      marginLeft: theme.spacing(2),
+      marginRight: theme.spacing(2),
+      marginTop: theme.spacing(1),
+    },
+    clubTitle: {
+      marginBottom: theme.spacing(0),
+      maxWidth: '500px',
+    },
+    link: {
+      color: theme.palette.text.primary,
+      textDecoration: 'none'
+    },
+    listedClubsContainer: {
+      alignItems: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      marginBottom: theme.spacing(3),
+    },
+  }),
+);
+
+interface ClubListProps {
+  clubsToDisplay: ClubInterface[],
+  handleJoinClub(clubId: string, token:string): void,
+  userId: string,
+}
+
+/**
+ * Displays up to the number of clubs that the user has requested to
+ * the page.
+ */
+export function ClubList(props: ClubListProps) {
+  const classes = useStyles();
+  const clubsToDisplay = props.clubsToDisplay;
+
+  const contextServices = React.useContext(ServiceContext);
+  const loginStatusHandlerService = contextServices.loginStatusHandlerService;
+
+  const [joinClubAlertOpen, setJoinAlertOpen] = React.useState<boolean>(/* closed */ false);
+  const [nameOfClubAlert, setNameofClubAlert] = React.useState<string|undefined>(undefined);
+
+  const openAlertWindow = (clubId: string) => {
+    setNameofClubAlert(clubId);
+    setJoinAlertOpen(true);
+  }
+
+  const closeAlertWindow = () => {
+    setJoinAlertOpen(false);
+  }
+
+  const handleJoinClub = (clubId: string, token: string) => {
+    props.handleJoinClub(clubId, token);
+    setJoinAlertOpen(false);
+  }
+
+  /* If clubs to display is not yet defined. */
+  if (clubsToDisplay !== undefined)  {
+    return (
+      <div className={classes.listedClubsContainer}>
+        {clubsToDisplay.map((item, index) => (
+          <div className={classes.club} key={item.name}>
+            <Box border={1} borderColor="text.primary" borderRadius={16}>
+              <div className={classes.clubContent}>
+                <div className={classes.clubHeader}>
+                  <h2 className={classes.clubTitle}>{item.name}</h2>
+                  <div className={classes.buttonContainer}>
+                    <Link to={{
+                      pathname:'/Club/' + item.name,
+                      state: {club: item}
+                      }}
+                      className={classes.link}
+                      key={item.name}
+                    >
+                      <Button
+                        className={classes.button}
+                        color="primary"
+                        endIcon={<PageviewIcon />}
+                        variant="contained"
+                      >
+                        View Club
+                      </Button>
+                    </Link>
+                    <Button
+                      className={classes.button}
+                      color="secondary"
+                      endIcon={<HighlightOffIcon />}
+                      onClick={() => (openAlertWindow(item.name))}
+                      variant="contained"
+                    >
+                      Join Club
+                    </Button>
+                  </div>
+                </div>
+                <div className={classes.clubContent} >
+                  <ClubDescription description={item.description} />
+                </div>
+                <div className={classes.clubContent}>
+                  <BookInfo book={item.currentBook} />
+                  <ContentWarnings contentWarnings={item.contentWarnings} />
+                </div>
+                <JoinClubAlertWindow
+                  clubName={item.name}
+                  clubId={item.clubId}
+                  token={loginStatusHandlerService.getUserToken()}
+                  nameOfClubJoining={nameOfClubAlert}
+                  alertOpen={joinClubAlertOpen}
+                  handleAlertWindowClose={closeAlertWindow}
+                  handleJoinClub={handleJoinClub}
+                />
+              </div>
+            </Box>
+          </div>
+        ))}
+      </div>
+    );
+  } else {
+    return (<div></div>);
+  }
+}
+
+interface JoinClubAlertWindowProps {
+  clubId: string,
+  token: string,
+  clubName: string,
+  nameOfClubJoining: string,
+  alertOpen: boolean,
+  handleAlertWindowClose(): void,
+  handleJoinClub(clubId: string, token: string): void,
+}
+
+function JoinClubAlertWindow(props: JoinClubAlertWindowProps) {
+  return (
+    <Dialog open={props.alertOpen && (props.clubName === props.nameOfClubJoining)}>
+      <DialogTitle>Join Club '{props.clubName}'?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          By pressing 'Confirm', you will become a member of Club
+          '{props.clubName}'. This means that you will have access
+          to its content, including discussion forums and mailing lists.
+          Additionally, your name and email will appear on the mailing list.
+        </DialogContentText>
+        <DialogActions>
+          <Button onClick={props.handleAlertWindowClose} color="primary">
+            Cancel
+          </Button>
+          <Button
+            onClick={() => (props.handleJoinClub(props.clubId, props.token))} color="primary"
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/pages/explore/ExploreClubList.tsx
+++ b/frontend/src/components/pages/explore/ExploreClubList.tsx
@@ -12,7 +12,7 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import HighlightOffIcon from "@material-ui/icons/HighlightOff";
+import InputIcon from "@material-ui/icons/Input";
 import { Link } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles";
 import PageviewIcon from "@material-ui/icons/Pageview";
@@ -125,8 +125,8 @@ export function ExploreClubList(props: ExploreClubListProps) {
                     </Link>
                     <Button
                       className={classes.button}
-                      color="secondary"
-                      endIcon={<HighlightOffIcon />}
+                      color="primary"
+                      endIcon={<InputIcon />}
                       onClick={() => (openAlertWindow(item.name))}
                       variant="contained"
                     >

--- a/frontend/src/components/pages/explore/ExploreClubList.tsx
+++ b/frontend/src/components/pages/explore/ExploreClubList.tsx
@@ -16,7 +16,6 @@ import HighlightOffIcon from "@material-ui/icons/HighlightOff";
 import { Link } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles";
 import PageviewIcon from "@material-ui/icons/Pageview";
-import { ServiceContext } from "../../contexts/contexts";
 import { Theme } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -67,22 +66,18 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-interface ClubListProps {
+interface ExploreClubListProps {
   clubsToDisplay: ClubInterface[],
-  handleJoinClub(clubId: string, token:string): void,
-  userId: string,
+  handleJoinClub(clubId: string): void,
 }
 
 /**
  * Displays up to the number of clubs that the user has requested to
  * the page.
  */
-export function ClubList(props: ClubListProps) {
+export function ExploreClubList(props: ExploreClubListProps) {
   const classes = useStyles();
   const clubsToDisplay = props.clubsToDisplay;
-
-  const contextServices = React.useContext(ServiceContext);
-  const loginStatusHandlerService = contextServices.loginStatusHandlerService;
 
   const [joinClubAlertOpen, setJoinAlertOpen] = React.useState<boolean>(/* closed */ false);
   const [nameOfClubAlert, setNameofClubAlert] = React.useState<string|undefined>(undefined);
@@ -96,8 +91,8 @@ export function ClubList(props: ClubListProps) {
     setJoinAlertOpen(false);
   }
 
-  const handleJoinClub = (clubId: string, token: string) => {
-    props.handleJoinClub(clubId, token);
+  const handleJoinClub = (clubId: string) => {
+    props.handleJoinClub(clubId);
     setJoinAlertOpen(false);
   }
 
@@ -149,7 +144,6 @@ export function ClubList(props: ClubListProps) {
                 <JoinClubAlertWindow
                   clubName={item.name}
                   clubId={item.clubId}
-                  token={loginStatusHandlerService.getUserToken()}
                   nameOfClubJoining={nameOfClubAlert}
                   alertOpen={joinClubAlertOpen}
                   handleAlertWindowClose={closeAlertWindow}
@@ -168,12 +162,11 @@ export function ClubList(props: ClubListProps) {
 
 interface JoinClubAlertWindowProps {
   clubId: string,
-  token: string,
   clubName: string,
   nameOfClubJoining: string,
   alertOpen: boolean,
   handleAlertWindowClose(): void,
-  handleJoinClub(clubId: string, token: string): void,
+  handleJoinClub(clubId: string): void,
 }
 
 function JoinClubAlertWindow(props: JoinClubAlertWindowProps) {
@@ -192,7 +185,7 @@ function JoinClubAlertWindow(props: JoinClubAlertWindowProps) {
             Cancel
           </Button>
           <Button
-            onClick={() => (props.handleJoinClub(props.clubId, props.token))} color="primary"
+            onClick={() => (props.handleJoinClub(props.clubId))} color="primary"
           >
             Confirm
           </Button>

--- a/frontend/src/components/pages/your_clubs/YourClubs.tsx
+++ b/frontend/src/components/pages/your_clubs/YourClubs.tsx
@@ -53,10 +53,10 @@ export const YourClubs = () => {
   const [listedClubs, setListedClubs] =
     React.useState<ClubInterface[]|undefined>(undefined);
   const [numClubsDisplayed, setNumClubsDisplayed] =
-    React.useState<number|undefined>(DEFAULT_NUM_DISPLAYED);
+    React.useState<number>(DEFAULT_NUM_DISPLAYED);
   const [createNewClub, setCreateNewClub] = React.useState<boolean>(false);
 
-  /* Re-renders Profile only when number of displayed clubs changes. */
+  /* Re-renders YourClubs only when number of displayed clubs changes. */
   React.useEffect(() => {
     (async() => {
       const numClubsToDisplay = numClubsDisplayed
@@ -64,7 +64,6 @@ export const YourClubs = () => {
         : setNumClubsDisplayed(DEFAULT_NUM_DISPLAYED)
       updateClubList();
     })();
-    console.log(numClubsDisplayed);
   }, [numClubsDisplayed]);
 
   const handleNumClubsChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/components/pages/your_clubs/YourClubs.tsx
+++ b/frontend/src/components/pages/your_clubs/YourClubs.tsx
@@ -5,12 +5,9 @@ import { ClubInterface } from "../../../services/backend_service_interface/backe
 import { ClubList } from "./ClubList";
 import { CreateNewClubWindow } from "./CreateNewClub";
 import { createStyles } from "@material-ui/core/styles";
-import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
-import InputLabel from "@material-ui/core/InputLabel";
+import { DEFAULT_NUM_DISPLAYED } from "../club_display/club_display_consts";
 import { makeStyles } from "@material-ui/core/styles";
-import MenuItem from "@material-ui/core/MenuItem";
-import Select from "@material-ui/core/Select";
+import { NumClubsToDisplay } from "../club_display/NumClubsToDisplay";
 import { ServiceContext } from "../../contexts/contexts";
 import { Theme } from "@material-ui/core/styles";
 
@@ -44,7 +41,6 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export const YourClubs = () => {
   const classes = useStyles();
-  const DEFAULT_NUM_DISPLAYED = 10;
 
   /**
    * ServiceHandlers is an object containing various TS Handlers and provides
@@ -68,6 +64,7 @@ export const YourClubs = () => {
         : setNumClubsDisplayed(DEFAULT_NUM_DISPLAYED)
       updateClubList();
     })();
+    console.log(numClubsDisplayed);
   }, [numClubsDisplayed]);
 
   const handleNumClubsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -113,26 +110,11 @@ export const YourClubs = () => {
   return (
     <div className={classes.root}>
       <div className={classes.topUtilitiesContainer}>
-        <FormControl className={classes.formControl}>
-          <InputLabel id="number-of-displayed-clubs-label">
-            Number of Displayed Clubs
-          </InputLabel>
-          <Select
-            labelId="number-of-displayed-clubs-label"
-            id="number-of-displayed-clubs"
-            value={numClubsDisplayed ? numClubsDisplayed : DEFAULT_NUM_DISPLAYED}
-            onChange={handleNumClubsChange}
-            label="Age"
-          >
-            <MenuItem value={10}>10</MenuItem>
-            <MenuItem value={25}>25</MenuItem>
-            <MenuItem value={50}>50</MenuItem>
-            <MenuItem value={100}>100</MenuItem>
-          </Select>
-          <FormHelperText>
-            The number of clubs of which you are a member to be displayed.
-          </FormHelperText>
-        </FormControl>
+        <NumClubsToDisplay
+          handleNumClubsChange={handleNumClubsChange}
+          numClubsDisplayed={numClubsDisplayed}
+          showClubsMemberOf={true}
+        />
         <Button
           className={classes.button}
           color="primary"


### PR DESCRIPTION
Implements /Explore page functionality, which presents to the user clubs that they are not a member of. Users are given the option to join or view the club. Upon clicking join club, users will subsequently be prompted with a confirmation window. If they click confirm, the club will be removed from the /Explore page and be found on the /YourClubs page.

## Screenshots: ##
Explore Page: https://screenshot.googleplex.com/CRMvE3Uc0X0.png
Alert Window: https://screenshot.googleplex.com/DkkmGkAa3vc.png
Updated YourClubs Page: https://screenshot.googleplex.com/1tk0bw78xpK.png