### PR TITLE
Fix ID token validation so it doesn't fail after an hour.

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -16,7 +16,6 @@ package com.google.coffeehouse.servlets;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -24,6 +23,7 @@ import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -54,7 +54,7 @@ public class GetProfileServlet extends HttpServlet {
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
   private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-  private final GoogleIdTokenVerifier verifier;
+  private final TokenVerifier verifier;
   private final StorageHandlerApi storageHandler;
 
   /**
@@ -62,7 +62,7 @@ public class GetProfileServlet extends HttpServlet {
    * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Person
    */
-  public GetProfileServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+  public GetProfileServlet(TokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
     this.verifier = verifier;
@@ -74,7 +74,7 @@ public class GetProfileServlet extends HttpServlet {
   public GetProfileServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
-    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+    this.verifier = new TokenVerifier();
   }
   
   /** 

--- a/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/GetProfileServlet.java
@@ -14,8 +14,6 @@
 
 package com.google.coffeehouse.servlets;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;

--- a/server/src/main/java/com/google/coffeehouse/servlets/JoinClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/JoinClubServlet.java
@@ -25,6 +25,7 @@ import com.google.coffeehouse.common.MembershipConstants;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -69,7 +70,7 @@ public class JoinClubServlet extends HttpServlet {
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
   private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-  private final GoogleIdTokenVerifier verifier;
+  private final TokenVerifier verifier;
   private final StorageHandlerApi storageHandler;
 
   /**
@@ -77,7 +78,7 @@ public class JoinClubServlet extends HttpServlet {
    * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when adding the membership
    */
-  public JoinClubServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+  public JoinClubServlet(TokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
     this.verifier = verifier;
@@ -89,7 +90,7 @@ public class JoinClubServlet extends HttpServlet {
   public JoinClubServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
-    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+    this.verifier = new TokenVerifier();
   }
 
   /**

--- a/server/src/main/java/com/google/coffeehouse/servlets/JoinClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/JoinClubServlet.java
@@ -14,9 +14,6 @@
 
 package com.google.coffeehouse.servlets;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;

--- a/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
@@ -16,7 +16,6 @@ package com.google.coffeehouse.servlets;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -25,6 +24,7 @@ import com.google.coffeehouse.common.MembershipConstants;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -68,7 +68,7 @@ public class LeaveClubServlet extends HttpServlet {
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
   private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-  private final GoogleIdTokenVerifier verifier;
+  private final TokenVerifier verifier;
   private final StorageHandlerApi storageHandler;
 
   /**
@@ -76,7 +76,7 @@ public class LeaveClubServlet extends HttpServlet {
    * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when deleting the membership
    */
-  public LeaveClubServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+  public LeaveClubServlet(TokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
     this.verifier = verifier;
@@ -88,7 +88,7 @@ public class LeaveClubServlet extends HttpServlet {
   public LeaveClubServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
-    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+    this.verifier = new TokenVerifier();
   }
 
   /**

--- a/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
@@ -14,8 +14,6 @@
 
 package com.google.coffeehouse.servlets;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;

--- a/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/ListClubsServlet.java
@@ -16,7 +16,6 @@ package com.google.coffeehouse.servlets;
 
 import static com.google.coffeehouse.common.MembershipConstants.MembershipStatus;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -24,6 +23,7 @@ import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -71,7 +71,7 @@ public class ListClubsServlet extends HttpServlet {
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
   private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-  private final GoogleIdTokenVerifier verifier;
+  private final TokenVerifier verifier;
   private final StorageHandlerApi storageHandler;
 
   /** 
@@ -79,7 +79,7 @@ public class ListClubsServlet extends HttpServlet {
    * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Clubs
    */
-  public ListClubsServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+  public ListClubsServlet(TokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
     this.verifier = verifier;
@@ -91,7 +91,7 @@ public class ListClubsServlet extends HttpServlet {
   public ListClubsServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
-    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+    this.verifier = new TokenVerifier();
   }
 
   /**

--- a/server/src/main/java/com/google/coffeehouse/servlets/RetrieveTokenServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/RetrieveTokenServlet.java
@@ -128,7 +128,10 @@ public class RetrieveTokenServlet extends HttpServlet {
 
     try {
       // Perform basic security to make sure the ID token is valid.
-      AuthenticationHelper.getUserIdFromIdToken(idToken, verifier);
+      GoogleIdToken partialIdToken = verifier.verify(idToken);
+      if (partialIdToken == null) {
+        throw new GeneralSecurityException(idToken);
+      }
     } catch (Exception e) {
       System.out.println(LOG_INVALID_ID_TOKEN_MESSAGE + e.getMessage());
       response.sendError(HttpServletResponse.SC_FORBIDDEN, INVALID_ID_TOKEN);

--- a/server/src/main/java/com/google/coffeehouse/servlets/UpdateClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/UpdateClubServlet.java
@@ -16,7 +16,6 @@ package com.google.coffeehouse.servlets;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -25,6 +24,7 @@ import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -90,7 +90,7 @@ public class UpdateClubServlet extends HttpServlet {
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
   private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-  private final GoogleIdTokenVerifier verifier;
+  private final TokenVerifier verifier;
   private final StorageHandlerApi storageHandler;
 
   /** 
@@ -98,7 +98,7 @@ public class UpdateClubServlet extends HttpServlet {
    * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Club/Book
    */
-  public UpdateClubServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+  public UpdateClubServlet(TokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
     this.verifier = verifier;
@@ -110,7 +110,7 @@ public class UpdateClubServlet extends HttpServlet {
   public UpdateClubServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
-    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+    this.verifier = new TokenVerifier();
   }
 
   /** 

--- a/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
@@ -23,6 +23,7 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.IOException;
@@ -75,7 +76,7 @@ public class UpdatePersonServlet extends HttpServlet {
   private static final Gson gson = new Gson();
   private static final HttpTransport transport = new NetHttpTransport();
   private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-  private final GoogleIdTokenVerifier verifier;
+  private final TokenVerifier verifier;
   private final StorageHandlerApi storageHandler;
 
   /** 
@@ -83,7 +84,7 @@ public class UpdatePersonServlet extends HttpServlet {
    * @param verifier the class that verifies the validity of the ID token
    * @param storageHandler the {@link StorageHandlerApi} that is used when fetching the Person
    */
-  public UpdatePersonServlet(GoogleIdTokenVerifier verifier, StorageHandlerApi storageHandler) {
+  public UpdatePersonServlet(TokenVerifier verifier, StorageHandlerApi storageHandler) {
     super();
     this.storageHandler = storageHandler;
     this.verifier = verifier;
@@ -95,7 +96,7 @@ public class UpdatePersonServlet extends HttpServlet {
   public UpdatePersonServlet() {
     super();
     this.storageHandler = new StorageHandlerApi();
-    this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory).build();
+    this.verifier = new TokenVerifier();
   }
 
   /** 

--- a/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/UpdatePersonServlet.java
@@ -14,9 +14,6 @@
 
 package com.google.coffeehouse.servlets;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;

--- a/server/src/main/java/com/google/coffeehouse/util/AuthenticationHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/util/AuthenticationHelper.java
@@ -15,10 +15,10 @@
 package com.google.coffeehouse.util;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.coffeehouse.util.TokenVerifier;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -51,16 +51,16 @@ public class AuthenticationHelper {
    * @throws GeneralSecurityException if the ID token is invalid or null
    * @throws IOException if an input or output error is detected when the ID token is verified
    */
-  public static String getUserIdFromIdToken(String idTokenString, GoogleIdTokenVerifier verifier)
-    throws GeneralSecurityException, IOException {
+  public static String getUserIdFromIdToken(String idTokenString, TokenVerifier verifier)
+    throws GeneralSecurityException {
     if (idTokenString == null) {
       throw new GeneralSecurityException(INVALID_ID_TOKEN_ERROR);
     }
-    GoogleIdToken idToken = verifier.verify(idTokenString);
-    if (idToken == null) {
+    String subject = verifier.getSubject(idTokenString);
+    if (subject == null) {
       throw new GeneralSecurityException(INVALID_ID_TOKEN_ERROR);
     }
-    return (String) idToken.getPayload().getSubject();
+    return subject;
   }
 
   // Private constructor to enforce that it should not be instantiated.

--- a/server/src/main/java/com/google/coffeehouse/util/TokenVerifier.java
+++ b/server/src/main/java/com/google/coffeehouse/util/TokenVerifier.java
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.coffeehouse.util;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.json.gson.GsonFactory;
+
+/**
+ * A class that verifies an ID token and returns its subject.
+ */
+public class TokenVerifier {
+  private static final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+  
+  /**
+   * Gets the subject of an ID token.
+   * @param token a string representation of the ID token
+   * @return the subject of the token if it is valid, otherwise null
+   */
+  public String getSubject(String token) {
+    try {
+      GoogleIdToken idToken = GoogleIdToken.parse(jsonFactory, token);
+      if (idToken.verifySignature() == null) {
+        return null;
+      }
+      return idToken.getPayload().getSubject();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/server/src/test/java/com/google/coffeehouse/servlets/CreateClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/CreateClubServletTest.java
@@ -164,30 +164,6 @@ public class CreateClubServletTest {
   }
 
   @Test
-  public void doPost_maximumValidInput() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(MAXIMUM_JSON)));
-
-    CreateClubServlet.doPost(request, response);
-    String result = stringWriter.toString();
-
-    Gson gson = new Gson();
-    Club c = gson.fromJson(result, Club.class);
-
-    assertEquals(NAME, c.getName());
-    assertEquals(CLUB_ID, c.getClubId());
-    assertEquals(OWNER_ID, c.getOwnerId());
-    assertEquals(testContentWarnings, c.getContentWarnings());
-    assertEquals(DESCRIPTION, c.getDescription());
-    assertEquals(BOOK_TITLE, c.getCurrentBook().getTitle());
-    assertEquals(CLUB_ID, c.getCurrentBook().getBookId());
-    assertTrue(c.getCurrentBook().getAuthor().isPresent());
-    assertEquals(BOOK_AUTHOR, c.getCurrentBook().getAuthor().get());
-    assertTrue(c.getCurrentBook().getIsbn().isPresent());
-    assertEquals(BOOK_ISBN, c.getCurrentBook().getIsbn().get());
-  }
-
-  @Test
   public void doPost_noNameSpecified() throws IOException {
     when(request.getReader()).thenReturn(
           new BufferedReader(new StringReader(NO_NAME_JSON)));

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.servlets.GetProfileServlet;

--- a/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/GetProfileServletTest.java
@@ -24,13 +24,13 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.servlets.GetProfileServlet;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -71,10 +71,8 @@ public class GetProfileServletTest {
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi successfulHandler;
   @Mock private StorageHandlerApi failingHandler;
-  @Mock private GoogleIdTokenVerifier correctVerifier;
-  @Mock private GoogleIdTokenVerifier nullVerifier;
-  @Mock private GoogleIdToken correctIdToken;
-  @Mock private Payload correctPayload;
+  @Mock private TokenVerifier correctVerifier;
+  @Mock private TokenVerifier nullVerifier;
   
   @Before
   public void setUp() throws IOException, GeneralSecurityException {
@@ -93,16 +91,12 @@ public class GetProfileServletTest {
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
 
     // Verification setup that successfully verifies and gives correct userId.
-    correctPayload = mock(Payload.class);
-    when(correctPayload.getSubject()).thenReturn(USER_ID);
-    correctIdToken = mock(GoogleIdToken.class);
-    when(correctIdToken.getPayload()).thenReturn(correctPayload);
-    correctVerifier = mock(GoogleIdTokenVerifier.class);
-    when(correctVerifier.verify(anyString())).thenReturn(correctIdToken);
+    correctVerifier = mock(TokenVerifier.class);
+    when(correctVerifier.getSubject(anyString())).thenReturn(USER_ID);
 
     // Verification setup that does not successfully verify.
-    nullVerifier = mock(GoogleIdTokenVerifier.class);
-    when(nullVerifier.verify(anyString())).thenReturn(null);
+    nullVerifier = mock(TokenVerifier.class);
+    when(nullVerifier.getSubject(anyString())).thenReturn(null);
   }
 
   @After

--- a/server/src/test/java/com/google/coffeehouse/servlets/JoinClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/JoinClubServletTest.java
@@ -25,13 +25,13 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.MembershipConstants;
 import com.google.coffeehouse.servlets.JoinClubServlet;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -79,10 +79,8 @@ public class JoinClubServletTest {
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi failingHandler;
   @Spy private StorageHandlerApi successfulHandlerSpy;
-  @Mock private GoogleIdTokenVerifier correctVerifier;
-  @Mock private GoogleIdTokenVerifier nullVerifier;
-  @Mock private GoogleIdToken correctIdToken;
-  @Mock private Payload correctPayload;
+  @Mock private TokenVerifier correctVerifier;
+  @Mock private TokenVerifier nullVerifier;
 
   @Before
   public void setUp() throws IOException, GeneralSecurityException {
@@ -101,16 +99,12 @@ public class JoinClubServletTest {
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
 
     // Verification setup that successfully verifies and gives correct userId.
-    correctPayload = mock(Payload.class);
-    when(correctPayload.getSubject()).thenReturn(USER_ID);
-    correctIdToken = mock(GoogleIdToken.class);
-    when(correctIdToken.getPayload()).thenReturn(correctPayload);
-    correctVerifier = mock(GoogleIdTokenVerifier.class);
-    when(correctVerifier.verify(anyString())).thenReturn(correctIdToken);
+    correctVerifier = mock(TokenVerifier.class);
+    when(correctVerifier.getSubject(anyString())).thenReturn(USER_ID);
 
     // Verification setup that does not successfully verify.
-    nullVerifier = mock(GoogleIdTokenVerifier.class);
-    when(nullVerifier.verify(anyString())).thenReturn(null);
+    nullVerifier = mock(TokenVerifier.class);
+    when(nullVerifier.getSubject(anyString())).thenReturn(null);
   }
 
   @After

--- a/server/src/test/java/com/google/coffeehouse/servlets/JoinClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/JoinClubServletTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.MembershipConstants;

--- a/server/src/test/java/com/google/coffeehouse/servlets/LeaveClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/LeaveClubServletTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.MembershipConstants;
@@ -33,6 +32,7 @@ import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.servlets.LeaveClubServlet;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -80,10 +80,8 @@ public class LeaveClubServletTest {
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi failingHandler;
   @Spy private StorageHandlerApi successfulHandlerSpy;
-  @Mock private GoogleIdTokenVerifier correctVerifier;
-  @Mock private GoogleIdTokenVerifier nullVerifier;
-  @Mock private GoogleIdToken correctIdToken;
-  @Mock private Payload correctPayload;
+  @Mock private TokenVerifier correctVerifier;
+  @Mock private TokenVerifier nullVerifier;
 
   @Before
   public void setUp() throws IOException, GeneralSecurityException {
@@ -102,16 +100,12 @@ public class LeaveClubServletTest {
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
 
     // Verification setup that successfully verifies and gives correct userId.
-    correctPayload = mock(Payload.class);
-    when(correctPayload.getSubject()).thenReturn(USER_ID);
-    correctIdToken = mock(GoogleIdToken.class);
-    when(correctIdToken.getPayload()).thenReturn(correctPayload);
-    correctVerifier = mock(GoogleIdTokenVerifier.class);
-    when(correctVerifier.verify(anyString())).thenReturn(correctIdToken);
+    correctVerifier = mock(TokenVerifier.class);
+    when(correctVerifier.getSubject(anyString())).thenReturn(USER_ID);
 
     // Verification setup that does not successfully verify.
-    nullVerifier = mock(GoogleIdTokenVerifier.class);
-    when(nullVerifier.verify(anyString())).thenReturn(null);
+    nullVerifier = mock(TokenVerifier.class);
+    when(nullVerifier.getSubject(anyString())).thenReturn(null);
   }
 
   @After

--- a/server/src/test/java/com/google/coffeehouse/servlets/LeaveClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/LeaveClubServletTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.MembershipConstants;

--- a/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
@@ -23,13 +23,13 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Book;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -77,10 +77,8 @@ public class ListClubsServletTest {
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi memberHandler;
   @Mock private StorageHandlerApi notMemberHandler;
-  @Mock private GoogleIdTokenVerifier verifier;
-  @Mock private GoogleIdTokenVerifier nullVerifier;
-  @Mock private GoogleIdToken idToken;
-  @Mock private Payload payload;
+  @Mock private TokenVerifier verifier;
+  @Mock private TokenVerifier nullVerifier;
 
   @Before
   public void setUp() throws IOException, GeneralSecurityException {
@@ -99,16 +97,12 @@ public class ListClubsServletTest {
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
     
     // Verification setup that successfully verifies and gives userId.
-    payload = mock(Payload.class);
-    when(payload.getSubject()).thenReturn(OWNER_ID);
-    idToken = mock(GoogleIdToken.class);
-    when(idToken.getPayload()).thenReturn(payload);
-    verifier = mock(GoogleIdTokenVerifier.class);
-    when(verifier.verify(anyString())).thenReturn(idToken);
+    verifier = mock(TokenVerifier.class);
+    when(verifier.getSubject(anyString())).thenReturn(OWNER_ID);
 
     // Verification setup that does not successfully verify.
-    nullVerifier = mock(GoogleIdTokenVerifier.class);
-    when(nullVerifier.verify(anyString())).thenReturn(null);
+    nullVerifier = mock(TokenVerifier.class);
+    when(nullVerifier.getSubject(anyString())).thenReturn(null);
   }
 
   @After

--- a/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Book;
 import com.google.coffeehouse.common.Club;

--- a/server/src/test/java/com/google/coffeehouse/servlets/UpdateClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/UpdateClubServletTest.java
@@ -25,13 +25,13 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.Book;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -183,13 +183,9 @@ public class UpdateClubServletTest {
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi handler;
-  @Mock private GoogleIdTokenVerifier correctVerifier;
-  @Mock private GoogleIdTokenVerifier incorrectVerifier;
-  @Mock private GoogleIdTokenVerifier nullVerifier;
-  @Mock private GoogleIdToken correctIdToken;
-  @Mock private GoogleIdToken incorrectIdToken;
-  @Mock private Payload correctPayload;
-  @Mock private Payload incorrectPayload;
+  @Mock private TokenVerifier correctVerifier;
+  @Mock private TokenVerifier incorrectVerifier;
+  @Mock private TokenVerifier nullVerifier;
 
   @Before
   public void setUp() throws IOException, GeneralSecurityException {
@@ -204,24 +200,16 @@ public class UpdateClubServletTest {
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
 
     // Verification setup that successfully verifies and gives correct userId.
-    correctPayload = mock(Payload.class);
-    when(correctPayload.getSubject()).thenReturn(OWNER_ID);
-    correctIdToken = mock(GoogleIdToken.class);
-    when(correctIdToken.getPayload()).thenReturn(correctPayload);
-    correctVerifier = mock(GoogleIdTokenVerifier.class);
-    when(correctVerifier.verify(anyString())).thenReturn(correctIdToken);
+    correctVerifier = mock(TokenVerifier.class);
+    when(correctVerifier.getSubject(anyString())).thenReturn(OWNER_ID);
 
     // Verification setup that successfully verifies and gives incorrect userId.
-    incorrectPayload = mock(Payload.class);
-    when(incorrectPayload.getSubject()).thenReturn(ALT_OWNER_ID);
-    incorrectIdToken = mock(GoogleIdToken.class);
-    when(incorrectIdToken.getPayload()).thenReturn(incorrectPayload);
-    incorrectVerifier = mock(GoogleIdTokenVerifier.class);
-    when(incorrectVerifier.verify(anyString())).thenReturn(incorrectIdToken);
+    incorrectVerifier = mock(TokenVerifier.class);
+    when(incorrectVerifier.getSubject(anyString())).thenReturn(ALT_OWNER_ID);
 
     // Verification setup that does not successfully verify.
-    nullVerifier = mock(GoogleIdTokenVerifier.class);
-    when(nullVerifier.verify(anyString())).thenReturn(null);
+    nullVerifier = mock(TokenVerifier.class);
+    when(nullVerifier.getSubject(anyString())).thenReturn(null);
   }
 
   @After

--- a/server/src/test/java/com/google/coffeehouse/servlets/UpdateClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/UpdateClubServletTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Club;
 import com.google.coffeehouse.common.Book;

--- a/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;

--- a/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/UpdatePersonServletTest.java
@@ -25,11 +25,11 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Person;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.util.AuthenticationHelper;
+import com.google.coffeehouse.util.TokenVerifier;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -138,10 +138,8 @@ public class UpdatePersonServletTest {
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   @Mock private StorageHandlerApi handler;
-  @Mock private GoogleIdTokenVerifier verifier;
-  @Mock private GoogleIdTokenVerifier nullVerifier;
-  @Mock private GoogleIdToken idToken;
-  @Mock private Payload payload;
+  @Mock private TokenVerifier verifier;
+  @Mock private TokenVerifier nullVerifier;
 
   @Before
   public void setUp() throws IOException, GeneralSecurityException {
@@ -156,16 +154,12 @@ public class UpdatePersonServletTest {
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
 
     // Verification setup that successfully verifies and gives correct userId.
-    payload = mock(Payload.class);
-    when(payload.getSubject()).thenReturn(USER_ID);
-    idToken = mock(GoogleIdToken.class);
-    when(idToken.getPayload()).thenReturn(payload);
-    verifier = mock(GoogleIdTokenVerifier.class);
-    when(verifier.verify(anyString())).thenReturn(idToken);
+    verifier = mock(TokenVerifier.class);
+    when(verifier.getSubject(anyString())).thenReturn(USER_ID);
 
     // Verification setup that does not successfully verify.
-    nullVerifier = mock(GoogleIdTokenVerifier.class);
-    when(nullVerifier.verify(anyString())).thenReturn(null);
+    nullVerifier = mock(TokenVerifier.class);
+    when(nullVerifier.getSubject(anyString())).thenReturn(null);
 
     updatePersonServlet = new UpdatePersonServlet(verifier, handler);
     failingUpdatePersonServlet = new UpdatePersonServlet(nullVerifier, handler);

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -58,7 +58,7 @@ public class StorageHandlerHelperTest {
   @Test
   public void checkAnyMembership_personInClub() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
-    StorageHandlerTestHelper.insertClub("club");
+    StorageHandlerTestHelper.insertClubWithContentWarnings("club");
     StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
     ReadContext readContext = dbClient.singleUse();
     Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");


### PR DESCRIPTION
Previously, the ID token validation would start to fail 1 hour after the token was granted, this is because the GoogleTokenVerifier checks if the token is old. We however, don't care if the token is old. The fix is to just verify the signature, issuer, and audience ourselves.

The majority of this PR is reworking our dependency injection to work with this new TokenVerifier class. 