### PR TITLE
Refactor Storage Handler

### DIFF
--- a/server/src/main/java/com/google/coffeehouse/common/MembershipConstants.java
+++ b/server/src/main/java/com/google/coffeehouse/common/MembershipConstants.java
@@ -22,6 +22,7 @@ public class MembershipConstants {
   public static final int OWNER = 2;
 
   public static final String PERSON_ALREADY_IN_CLUB = "Person is already a member of club.";
+  public static final String NO_CLUBS = "No clubs that the person is a \"%s\" of.";
   public static final String OWNER_CAN_NOT_LEAVE_CLUB = "Owner can't leave club they created.";
   public static final String PERSON_NOT_IN_CLUB = "Person is not a member of club.";
 

--- a/server/src/main/java/com/google/coffeehouse/common/MembershipConstants.java
+++ b/server/src/main/java/com/google/coffeehouse/common/MembershipConstants.java
@@ -22,7 +22,6 @@ public class MembershipConstants {
   public static final int OWNER = 2;
 
   public static final String PERSON_ALREADY_IN_CLUB = "Person is already a member of club.";
-  public static final String NO_CLUBS = "No clubs that the person is a \"%s\" of.";
   public static final String OWNER_CAN_NOT_LEAVE_CLUB = "Owner can't leave club they created.";
   public static final String PERSON_NOT_IN_CLUB = "Person is not a member of club.";
 

--- a/server/src/main/java/com/google/coffeehouse/common/MembershipConstants.java
+++ b/server/src/main/java/com/google/coffeehouse/common/MembershipConstants.java
@@ -22,6 +22,7 @@ public class MembershipConstants {
   public static final int OWNER = 2;
 
   public static final String PERSON_ALREADY_IN_CLUB = "Person is already a member of club.";
+  public static final String OWNER_CAN_NOT_LEAVE_CLUB = "Owner can't leave club they created.";
   public static final String PERSON_NOT_IN_CLUB = "Person is not a member of club.";
 
   public static final String NO_MEMBERS = "No members in club.";

--- a/server/src/main/java/com/google/coffeehouse/servlets/CreateClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/CreateClubServlet.java
@@ -59,7 +59,6 @@ public class CreateClubServlet extends HttpServlet {
    * Overloaded constructor for dependency injection.
    * @param handler the {@link StorageHandlerApi} that is used when saving the Club
    * @param idGen the {@link IdentifierGenerator} that is used when constructing the Club
-   * @param handler the {@link StorageHandlerApi} that is used when saving the Club
    */
   public CreateClubServlet(StorageHandlerApi handler, IdentifierGenerator idGen) {
     super();

--- a/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
@@ -104,8 +104,9 @@ public class LeaveClubServlet extends HttpServlet {
    * @param response the response from this method, will set the status to 200 (OK).
    *     If the request object has a valid JSON body without the required fields "idToken" and
    *     "clubId", the response will send a "400 Bad Request error". If the request object is
-   *     attempting to delete a membership which does not exist in the database, the response will
-   *     send a "409 Conflict" status. If the request object is unable to be parsed, the response
+   *     attempting to delete a membership which does not exist in the database, or if the request
+   *     object is attempting to delete the membership of an owner, the response will send a
+   *     "409 Conflict" status. If the request object is unable to be parsed, the response
    *     will send a "500 Internal Server error". If the request object does not have a valid ID
    *     token, the response object will send a "403 Forbidden error"
    * @throws IOException if an input or output error is detected when the servlet handles the request

--- a/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
+++ b/server/src/main/java/com/google/coffeehouse/servlets/LeaveClubServlet.java
@@ -128,12 +128,16 @@ public class LeaveClubServlet extends HttpServlet {
       }
       storageHandler.deleteMembership(userId, clubId);
     } catch (IllegalArgumentException e) {
-      System.out.println(LOG_INPUT_ERROR_MESSAGE + e.getMessage());
-      if (e.getMessage() == MembershipConstants.PERSON_NOT_IN_CLUB) {
+      String error = e.getMessage();
+      System.out.println(LOG_INPUT_ERROR_MESSAGE + error);
+      if (error == MembershipConstants.PERSON_NOT_IN_CLUB) {
         response.sendError(HttpServletResponse.SC_CONFLICT,
                            MembershipConstants.PERSON_NOT_IN_CLUB);
+      } else if (error == MembershipConstants.OWNER_CAN_NOT_LEAVE_CLUB) {
+        response.sendError(HttpServletResponse.SC_CONFLICT,
+                           MembershipConstants.OWNER_CAN_NOT_LEAVE_CLUB);
       } else {
-        response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, error);
       }
       return;
     } catch (GeneralSecurityException e) {

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -186,10 +186,12 @@ public class StorageHandler {
 
   /**
   * Runs a transaction that deletes a membership (or ownership) from the database.
-  * This method checks if a person is already a member of a club by calling a helper function.
-  * If the person does exist, this method will buffer a single mutation that deletes the
-  * membership. Otherwise, it will throw an exception indicating that the person is
-  * already not a member of the club.
+  * This method checks if the person is already a member of a club by calling a helper function.
+  * This method also checks if the person is the owner of the club by calling a helper function.
+  * If the person is a member, and not the owner, this method will buffer a single mutation
+  * that deletes the membership. If the person is the owner of the club, it will throw an exception
+  * indicating that the owner can not leave their own club. If the person is not a member, it will
+  * throw an exception indicating that the person is already not a member of the club.
   *
   * @param  dbClient    the database client
   * @param  userId      the user ID string used to perform the transaction

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -197,8 +197,11 @@ public class StorageHandler {
   * @param  userId      the user ID string used to perform the transaction
   * @param  clubId      the club ID string used to perform the transaction
   */
-  public static void runDeleteMembershipTransaction(DatabaseClient dbClient, String userId,
-                                                                             String clubId) {
+  public static void runDeleteMembershipTransaction(
+    DatabaseClient dbClient, 
+    String userId, 
+    String clubId
+  ) {
     dbClient
         .readWriteTransaction()
         .run(

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -248,7 +248,7 @@ public class StorageHandler {
       persons.add(getPerson(dbClient, resultSet.getString(/* userIdIndex= */0)));
     }
     if (persons.size() == 0) {
-      throw new IllegalArgumentException(MembershipConstants.NO_MEMBERS);
+      throw new IllegalStateException(MembershipConstants.NO_MEMBERS);
     }
     return persons;
   }
@@ -256,8 +256,7 @@ public class StorageHandler {
   /**
   * Creates and returns a list of {@link Club}s depending on the user's membership status.
   * This method builds a {@link Club} for each club that a user is either a member of
-  * or not a member of. Each {@link Club} is added to a list that gets returned. If there are no
-  * club, this method will throw an exception indicating that there are no members in the club.
+  * or not a member of. Each {@link Club} is added to a list that gets returned.
   *
   * @param  dbClient          the database client
   * @param  userId            the user ID string used to query and get a list of clubs
@@ -292,10 +291,6 @@ public class StorageHandler {
     }
     while (resultSet.next()) {
       clubs.add(getClub(dbClient, resultSet.getString(/* clubIdIndex= */0)));
-    }
-    if (clubs.size() == 0) {
-      throw new IllegalArgumentException(
-        String.format(MembershipConstants.NO_CLUBS, membershipStatus));
     }
     return clubs;
   }

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -190,7 +190,7 @@ public class StorageHandler {
   * This method also checks if the person is the owner of the club by calling a helper function.
   * If the person is a member, and not the owner, this method will buffer a single mutation
   * that deletes the membership. If the person is the owner of the club, it will throw an exception
-  * indicating that the owner can not leave their own club. If the person is not a member, it will
+  * indicating that the owner can't leave their own club. If the person is not a member, it will
   * throw an exception indicating that the person is already not a member of the club.
   *
   * @param  dbClient    the database client

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -162,8 +162,12 @@ public class StorageHandler {
   * @param  clubId               the club ID string used to perform the transaction
   * @param  membershipLevel      the integer representing membership level (member or owner)
   */
-  public static void runAddAnyMembershipTypeTransaction(DatabaseClient dbClient, String userId,
-                                                            String clubId, int membershipLevel) {
+  public static void runAddAnyMembershipTypeTransaction(
+    DatabaseClient dbClient,
+    String userId,
+    String clubId,
+    int membershipLevel
+  ) {
     dbClient
         .readWriteTransaction()
         .run(
@@ -266,8 +270,11 @@ public class StorageHandler {
   * @param  membershipStatus  the enum specifying whether the user is a member or not
   * @return                   the list of Clubs objects
   */
-  public static List<Club> getListOfClubs(DatabaseClient dbClient, String userId,
-                                          MembershipConstants.MembershipStatus membershipStatus) {
+  public static List<Club> getListOfClubs(
+    DatabaseClient dbClient,
+    String userId,
+    MembershipConstants.MembershipStatus membershipStatus
+  ) {
     ResultSet resultSet;
     List<Club> clubs = new ArrayList<>();
     ReadOnlyTransaction transaction = dbClient.readOnlyTransaction();

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandler.java
@@ -225,8 +225,9 @@ public class StorageHandler {
 
   /**
   * Creates and returns a list of {@link Persons}s that are a member of a club.
-  * This method builds a {@link Person} for each person who is a member of the club
-  * specified by club ID. Each {@link Person} is added to a list that gets returned.
+  * This method builds a {@link Person} for each person who is a member of the club, as specified
+  * by club ID. Each {@link Person} is added to a list that gets returned. If there are no members,
+  * this method will throw an exception indicating that there are no members in the club.
   *
   * @param  dbClient    the database client
   * @param  clubId      the club ID string used to query
@@ -255,7 +256,8 @@ public class StorageHandler {
   /**
   * Creates and returns a list of {@link Club}s depending on the user's membership status.
   * This method builds a {@link Club} for each club that a user is either a member of
-  * or not a member of. Each {@link Club} is added to a list that gets returned.
+  * or not a member of. Each {@link Club} is added to a list that gets returned. If there are no
+  * club, this method will throw an exception indicating that there are no members in the club.
   *
   * @param  dbClient          the database client
   * @param  userId            the user ID string used to query and get a list of clubs
@@ -292,7 +294,8 @@ public class StorageHandler {
       clubs.add(getClub(dbClient, resultSet.getString(/* clubIdIndex= */0)));
     }
     if (clubs.size() == 0) {
-      throw new IllegalArgumentException(MembershipConstants.NO_MEMBERS);
+      throw new IllegalArgumentException(
+        String.format(MembershipConstants.NO_CLUBS, membershipStatus));
     }
     return clubs;
   }

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
@@ -93,6 +93,9 @@ public class StorageHandlerHelper {
       while (resultSet.next()) {
         count = resultSet.getLong("count");
       }
+      if (count == 0) {
+        throw new IllegalArgumentException(MembershipConstants.NO_MEMBERS);
+      } 
     }
     return count;
   }

--- a/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
+++ b/server/src/main/java/com/google/coffeehouse/storagehandler/StorageHandlerHelper.java
@@ -93,9 +93,6 @@ public class StorageHandlerHelper {
       while (resultSet.next()) {
         count = resultSet.getLong("count");
       }
-      if (count == 0) {
-        throw new IllegalArgumentException(MembershipConstants.NO_MEMBERS);
-      } 
     }
     return count;
   }

--- a/server/src/test/java/com/google/coffeehouse/servlets/CreateClubServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/CreateClubServletTest.java
@@ -164,30 +164,6 @@ public class CreateClubServletTest {
   }
 
   @Test
-  public void doPost_maximumValidInput() throws IOException {
-    when(request.getReader()).thenReturn(
-          new BufferedReader(new StringReader(MAXIMUM_JSON)));
-
-    CreateClubServlet.doPost(request, response);
-    String result = stringWriter.toString();
-
-    Gson gson = new Gson();
-    Club c = gson.fromJson(result, Club.class);
-
-    assertEquals(NAME, c.getName());
-    assertEquals(CLUB_ID, c.getClubId());
-    assertEquals(OWNER_ID, c.getOwnerId());
-    assertEquals(testContentWarnings, c.getContentWarnings());
-    assertEquals(DESCRIPTION, c.getDescription());
-    assertEquals(BOOK_TITLE, c.getCurrentBook().getTitle());
-    assertEquals(CLUB_ID, c.getCurrentBook().getBookId());
-    assertTrue(c.getCurrentBook().getAuthor().isPresent());
-    assertEquals(BOOK_AUTHOR, c.getCurrentBook().getAuthor().get());
-    assertTrue(c.getCurrentBook().getIsbn().isPresent());
-    assertEquals(BOOK_ISBN, c.getCurrentBook().getIsbn().get());
-  }
-
-  @Test
   public void doPost_noNameSpecified() throws IOException {
     when(request.getReader()).thenReturn(
           new BufferedReader(new StringReader(NO_NAME_JSON)));

--- a/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
+++ b/server/src/test/java/com/google/coffeehouse/servlets/ListClubsServletTest.java
@@ -27,6 +27,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.coffeehouse.common.Book;
 import com.google.coffeehouse.common.Club;
+import com.google.coffeehouse.common.MembershipConstants;
 import com.google.coffeehouse.storagehandler.StorageHandlerApi;
 import com.google.coffeehouse.storagehandler.StorageHandler;
 import com.google.coffeehouse.util.AuthenticationHelper;
@@ -93,6 +94,7 @@ public class ListClubsServletTest {
     notMemberHandler = mock(StorageHandlerApi.class);
     when(notMemberHandler.listClubsFromUserId(
         anyString(), eq(MembershipStatus.NOT_MEMBER))).thenReturn(Arrays.asList(testClub));
+
 
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
@@ -162,6 +164,38 @@ public class ListClubsServletTest {
     assertEquals(testContentWarnings, c.getContentWarnings());
     assertEquals(BOOK_TITLE, c.getCurrentBook().getTitle());
     assertEquals(BOOK_ID, c.getCurrentBook().getBookId());
+  }
+
+  @Test
+  public void doGet_noClubsToReturnWhenMemberOfAll() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, memberHandler);
+    when(request.getParameter(eq(ListClubsServlet.ID_TOKEN_PARAMETER))).thenReturn(ID_TOKEN);
+    when(request.getParameter(eq(ListClubsServlet.MEMBERSHIP_STATUS_PARAMETER)))
+        .thenReturn(ListClubsServlet.NOT_MEMBER);
+
+    listClubsServlet.doGet(request, response);
+    String result = stringWriter.toString();
+  
+    Gson gson = new Gson();
+    Club[] clubs = gson.fromJson(result, Club[].class);
+
+    assertEquals(0, clubs.length);
+  }
+
+  @Test
+  public void doGet_noClubsToReturnWhenNotMemberOfAll() throws IOException {
+    listClubsServlet = new ListClubsServlet(verifier, notMemberHandler);
+    when(request.getParameter(eq(ListClubsServlet.ID_TOKEN_PARAMETER))).thenReturn(ID_TOKEN);
+    when(request.getParameter(eq(ListClubsServlet.MEMBERSHIP_STATUS_PARAMETER)))
+        .thenReturn(ListClubsServlet.MEMBER);
+
+    listClubsServlet.doGet(request, response);
+    String result = stringWriter.toString();
+  
+    Gson gson = new Gson();
+    Club[] clubs = gson.fromJson(result, Club[].class);
+
+    assertEquals(0, clubs.length);
   }
 
   @Test

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -58,7 +58,7 @@ public class StorageHandlerHelperTest {
   @Test
   public void checkAnyMembership_personInClub() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
-    StorageHandlerTestHelper.insertClub("club");
+    StorageHandlerTestHelper.insertClubWithContentWarnings("club");
     StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
     ReadContext readContext = dbClient.singleUse();
     Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -120,8 +120,7 @@ public class StorageHandlerHelperTest {
   public void getMemberCount_noMember() throws Exception {
     StorageHandlerTestHelper.insertClubWithContentWarnings("club");
     ReadContext readContext = dbClient.singleUse();
-    assertThrows(RuntimeException.class, () -> {
-      StorageHandler.getListOfMembers(dbClient, "club");
-    });
+    long actual = StorageHandlerHelper.getMemberCount(readContext, "club");
+    assertEquals(0, actual);
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -95,7 +95,7 @@ public class StorageHandlerHelperTest {
   }
 
   @Test
-  public void checkOwnership_personIsMemberButNotOwner() throws Exception {
+  public void checkOwnership_personIsMember() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
     StorageHandlerTestHelper.insertPerson("owner");
     StorageHandlerTestHelper.insertClubWithContentWarnings("club");

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerHelperTest.java
@@ -120,7 +120,8 @@ public class StorageHandlerHelperTest {
   public void getMemberCount_noMember() throws Exception {
     StorageHandlerTestHelper.insertClubWithContentWarnings("club");
     ReadContext readContext = dbClient.singleUse();
-    long actual = StorageHandlerHelper.getMemberCount(readContext, "club");
-    assertEquals(0, actual);
+    assertThrows(RuntimeException.class, () -> {
+      StorageHandler.getListOfMembers(dbClient, "club");
+    });
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -204,12 +204,22 @@ public class StorageHandlerTest {
   }
 
   @Test
-  public void getDeleteMembershipTransaction() throws Exception {
+  public void runDeleteMembershipTransaction_member() throws Exception {
     StorageHandlerTestHelper.insertPerson("person");
     StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.MEMBER);
     StorageHandler.runDeleteMembershipTransaction(dbClient, "person", "club");
     ReadContext readContext = dbClient.singleUse();
     Boolean actual = StorageHandlerHelper.checkAnyMembership(readContext, "person", "club");
     assertFalse(actual);
+  }
+
+  @Test
+  public void runDeleteMembershipTransaction_ownerFailsToLeaveClub() throws Exception {
+    StorageHandlerTestHelper.insertPerson("person");
+    StorageHandlerTestHelper.insertMembership("person", "club", MembershipConstants.OWNER);
+    ReadContext readContext = dbClient.singleUse();
+    assertThrows(RuntimeException.class, () -> {
+      StorageHandler.runDeleteMembershipTransaction(dbClient, "person", "club");
+    });
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -66,7 +66,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertPersonWithPronouns("person");
     Person actual = StorageHandler.getPerson(dbClient, "person");
     Person expected = StorageHandlerTestHelper.createTestPersonObject(
-      "person", /* pronouns= */true);
+      "person", /* pronouns= */ true);
     assertEquals(actual.getNickname(), expected.getNickname());
     assertEquals(actual.getEmail(), expected.getEmail());
     assertEquals(actual.getUserId(), expected.getUserId());
@@ -78,7 +78,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertPersonWithNullPronouns("personWithNullPronouns");
     Person actual = StorageHandler.getPerson(dbClient, "personWithNullPronouns");
     Person expected = StorageHandlerTestHelper.createTestPersonObject(
-      "personWithNullPronouns", /* pronouns= */false);
+      "personWithNullPronouns", /* pronouns= */ false);
     assertEquals(actual.getNickname(), expected.getNickname());
     assertEquals(actual.getEmail(), expected.getEmail());
     assertEquals(actual.getUserId(), expected.getUserId());
@@ -98,8 +98,8 @@ public class StorageHandlerTest {
     Book actual = StorageHandler.getBook(dbClient, "book");
     Book expected = StorageHandlerTestHelper.createTestBookObject(
                                                 "book",
-                                                /* isbnExists= */true,
-                                                 /* authorExists= */true);
+                                                /* isbnExists= */ true,
+                                                 /* authorExists= */ true);
     assertEquals(actual.getTitle(), expected.getTitle());
     assertEquals(actual.getBookId(), expected.getBookId());
     assertEquals(actual.getAuthor(), expected.getAuthor());
@@ -112,8 +112,8 @@ public class StorageHandlerTest {
     Book actual = StorageHandler.getBook(dbClient, "bookNullIsbn");
     Book expected = StorageHandlerTestHelper.createTestBookObject(
                                                 "bookNullIsbn",
-                                                /* isbnExists= */false,
-                                                 /* authorExists= */true);
+                                                /* isbnExists= */ false,
+                                                 /* authorExists= */ true);
     assertEquals(actual.getTitle(), expected.getTitle());
     assertEquals(actual.getBookId(), expected.getBookId());
     assertEquals(actual.getAuthor(), expected.getAuthor());
@@ -126,8 +126,8 @@ public class StorageHandlerTest {
     Book actual = StorageHandler.getBook(dbClient, "bookNullAuthor");
     Book expected = StorageHandlerTestHelper.createTestBookObject(
                                                 "bookNullAuthor",
-                                                /* isbnExists= */true,
-                                                 /* authorExists= */false);
+                                                /* isbnExists= */ true,
+                                                 /* authorExists= */ false);
     assertEquals(actual.getTitle(), expected.getTitle());
     assertEquals(actual.getBookId(), expected.getBookId());
     assertEquals(actual.getIsbn(), expected.getIsbn());
@@ -140,8 +140,8 @@ public class StorageHandlerTest {
     Book actual = StorageHandler.getBook(dbClient, "bookNullAuthorNullIsbn");
     Book expected = StorageHandlerTestHelper.createTestBookObject(
                                                 "bookNullAuthorNullIsbn",
-                                                /* isbnExists= */false,
-                                                 /* authorExists= */false);
+                                                /* isbnExists= */ false,
+                                                 /* authorExists= */ false);
     assertEquals(actual.getTitle(), expected.getTitle());
     assertEquals(actual.getBookId(), expected.getBookId());
     assertFalse(actual.getAuthor().isPresent());
@@ -161,7 +161,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertClubWithContentWarnings("clubWithContentWarnings");
     Club actual = StorageHandler.getClub(dbClient, "clubWithContentWarnings");
     Club expected = StorageHandlerTestHelper.createTestClubObject(
-      "clubWithContentWarnings", /* contentWarnings= */true);
+      "clubWithContentWarnings", /* contentWarnings= */ true);
     assertEquals(actual.getName(), expected.getName());
     assertEquals(actual.getOwnerId(), expected.getOwnerId());
     assertEquals(actual.getClubId(), expected.getClubId());
@@ -177,7 +177,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertClubWithNoContentWarnings("clubWithNoContentWarnings");
     Club actual = StorageHandler.getClub(dbClient, "clubWithNoContentWarnings");
     Club expected = StorageHandlerTestHelper.createTestClubObject(
-      "clubWithNoContentWarnings", /* contentWarnings= */false);
+      "clubWithNoContentWarnings", /* contentWarnings= */ false);
     assertEquals(actual.getName(), expected.getName());
     assertEquals(actual.getOwnerId(), expected.getOwnerId());
     assertEquals(actual.getClubId(), expected.getClubId());
@@ -236,7 +236,7 @@ public class StorageHandlerTest {
 
   @Test
   public void getListOfMembers_none() throws Exception {
-    StorageHandlerTestHelper.insertClub("club", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("club", /* owner_id= */ "owner");
     assertThrows(RuntimeException.class, () -> {
       StorageHandler.getListOfMembers(dbClient, "club");
     });
@@ -245,10 +245,10 @@ public class StorageHandlerTest {
   @Test
   public void getListOfMembers_oneOwner() throws Exception {
     List<Person> expected = new ArrayList<Person>();
-    expected.add(StorageHandlerTestHelper.createTestPersonObject("owner", /* pronouns= */true));
+    expected.add(StorageHandlerTestHelper.createTestPersonObject("owner", /* pronouns= */ true));
 
     StorageHandlerTestHelper.insertPerson("owner");
-    StorageHandlerTestHelper.insertClub("club", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("club", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertMembership("owner", "club", MembershipConstants.OWNER);
     List<Person> actual =  new ArrayList<Person>(StorageHandler.getListOfMembers(dbClient, "club"));
 
@@ -262,11 +262,11 @@ public class StorageHandlerTest {
   @Test
   public void getListOfMembers_ownerAndMembers() throws Exception {
     List<Person> expected = new ArrayList<Person>();
-    expected.add(StorageHandlerTestHelper.createTestPersonObject("member", /* pronouns= */true));
-    expected.add(StorageHandlerTestHelper.createTestPersonObject("owner", /* pronouns= */true));
+    expected.add(StorageHandlerTestHelper.createTestPersonObject("member", /* pronouns= */ true));
+    expected.add(StorageHandlerTestHelper.createTestPersonObject("owner", /* pronouns= */ true));
 
     StorageHandlerTestHelper.insertPerson("owner");
-    StorageHandlerTestHelper.insertClub("club", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("club", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertMembership("owner", "club", MembershipConstants.OWNER);
 
     StorageHandlerTestHelper.insertPerson("member");
@@ -287,14 +287,17 @@ public class StorageHandlerTest {
   @Test
   public void getListOfClubs_memberOfAll() throws Exception {
     List<Club> expected = new ArrayList<Club>();
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs1", /* contentWarning= */true));
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs2", /* contentWarning= */true));
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs3", /* contentWarning= */true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject(
+      "clubs1", /* contentWarning= */ true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject(
+      "clubs2", /* contentWarning= */ true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject(
+      "clubs3", /* contentWarning= */ true));
 
     StorageHandlerTestHelper.insertPerson("member");
-    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertMembership("member", "clubs1", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs2", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs3", MembershipConstants.MEMBER);
@@ -317,10 +320,10 @@ public class StorageHandlerTest {
   @Test
   public void getListOfClubs_memberOfOne() throws Exception {
     List<Club> expected = new ArrayList<Club>();
-    expected.add(StorageHandlerTestHelper.createTestClubObject("club", /* contentWarning= */true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject("club", /* contentWarning= */ true));
     StorageHandlerTestHelper.insertPerson("member");
     StorageHandlerTestHelper.insertPerson("owner");
-    StorageHandlerTestHelper.insertClub("club", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("club", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertMembership("owner", "club", MembershipConstants.OWNER);
     StorageHandlerTestHelper.insertBook("book");
     StorageHandlerTestHelper.insertMembership("member", "club", MembershipConstants.MEMBER);
@@ -337,14 +340,17 @@ public class StorageHandlerTest {
   @Test
   public void getListOfClubs_memberOfNone() throws Exception {
     List<Club> expected = new ArrayList<Club>();
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs1", /* contentWarning= */true));
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs2", /* contentWarning= */true));
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs3", /* contentWarning= */true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject(
+      "clubs1", /* contentWarning= */ true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject(
+      "clubs2", /* contentWarning= */ true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject(
+      "clubs3", /* contentWarning= */ true));
     StorageHandlerTestHelper.insertPerson("non-member");
     StorageHandlerTestHelper.insertPerson("owner");    
-    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertBook("book");
     List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "non-member",
                                              MembershipConstants.MembershipStatus.NOT_MEMBER));
@@ -363,9 +369,9 @@ public class StorageHandlerTest {
   public void getListOfClubs_notMemberWhenMemberOfAllExistingClubs() throws Exception {
     StorageHandlerTestHelper.insertPerson("member");
     StorageHandlerTestHelper.insertPerson("owner");    
-    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertBook("book");
     StorageHandlerTestHelper.insertMembership("member", "clubs1", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs2", MembershipConstants.MEMBER);
@@ -379,9 +385,9 @@ public class StorageHandlerTest {
   public void getListOfClubs_memberWhenNotMemberOfAllExistingClubs() throws Exception {
     StorageHandlerTestHelper.insertPerson("member");
     StorageHandlerTestHelper.insertPerson("owner");    
-    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */ "owner");
+    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertBook("book");
     List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
                                              MembershipConstants.MembershipStatus.MEMBER));

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -360,11 +360,7 @@ public class StorageHandlerTest {
   }
 
   @Test
-  public void getListOfClubs_notMemberThrowsException() throws Exception {
-    List<Club> expected = new ArrayList<Club>();
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs1", /* contentWarning= */true));
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs2", /* contentWarning= */true));
-    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs3", /* contentWarning= */true));
+  public void getListOfClubs_notMemberWhenMemberOfAllExistingClubs() throws Exception {
     StorageHandlerTestHelper.insertPerson("member");
     StorageHandlerTestHelper.insertPerson("owner");    
     StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
@@ -374,9 +370,21 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertMembership("member", "clubs1", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs2", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs3", MembershipConstants.MEMBER);
-    assertThrows(RuntimeException.class, () -> {
-      StorageHandler.getListOfClubs(
-        dbClient, "member", MembershipConstants.MembershipStatus.NOT_MEMBER);
-    });
+    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
+                                             MembershipConstants.MembershipStatus.NOT_MEMBER));
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void getListOfClubs_memberWhenNotMemberOfAllExistingClubs() throws Exception {
+    StorageHandlerTestHelper.insertPerson("member");
+    StorageHandlerTestHelper.insertPerson("owner");    
+    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertBook("book");
+    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
+                                             MembershipConstants.MembershipStatus.MEMBER));
+    assertEquals(0, actual.size());
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -250,7 +250,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertPerson("owner");
     StorageHandlerTestHelper.insertClub("club", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertMembership("owner", "club", MembershipConstants.OWNER);
-    List<Person> actual =  new ArrayList<Person>(StorageHandler.getListOfMembers(dbClient, "club"));
+    List<Person> actual = new ArrayList<Person>(StorageHandler.getListOfMembers(dbClient, "club"));
 
     assertEquals(1, actual.size());
     assertEquals(expected.get(0).getNickname(), actual.get(0).getNickname());
@@ -271,7 +271,7 @@ public class StorageHandlerTest {
 
     StorageHandlerTestHelper.insertPerson("member");
     StorageHandlerTestHelper.insertMembership("member", "club", MembershipConstants.MEMBER);
-    List<Person> actual =  new ArrayList<Person>(StorageHandler.getListOfMembers(dbClient, "club"));
+    List<Person> actual = new ArrayList<Person>(StorageHandler.getListOfMembers(dbClient, "club"));
 
     assertEquals(2, actual.size());
     assertEquals(expected.size(), actual.size());
@@ -303,8 +303,8 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertMembership("member", "clubs3", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertBook("book");
     
-    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
-                                             MembershipConstants.MembershipStatus.MEMBER));
+    List<Club> actual = new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
+                                            MembershipConstants.MembershipStatus.MEMBER));
 
     assertEquals(3, actual.size());
     assertEquals(expected.size(), actual.size());
@@ -327,7 +327,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertMembership("owner", "club", MembershipConstants.OWNER);
     StorageHandlerTestHelper.insertBook("book");
     StorageHandlerTestHelper.insertMembership("member", "club", MembershipConstants.MEMBER);
-    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
+    List<Club> actual = new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
                                              MembershipConstants.MembershipStatus.MEMBER));
     assertEquals(1, actual.size());
     assertEquals(actual.get(0).getName(), expected.get(0).getName());
@@ -352,7 +352,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertBook("book");
-    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "non-member",
+    List<Club> actual = new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "non-member",
                                              MembershipConstants.MembershipStatus.NOT_MEMBER));
     assertEquals(3, actual.size());
     assertEquals(expected.size(), actual.size());
@@ -376,7 +376,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertMembership("member", "clubs1", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs2", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertMembership("member", "clubs3", MembershipConstants.MEMBER);
-    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
+    List<Club> actual = new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
                                              MembershipConstants.MembershipStatus.NOT_MEMBER));
     assertEquals(0, actual.size());
   }
@@ -389,7 +389,7 @@ public class StorageHandlerTest {
     StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */ "owner");
     StorageHandlerTestHelper.insertBook("book");
-    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
+    List<Club> actual = new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
                                              MembershipConstants.MembershipStatus.MEMBER));
     assertEquals(0, actual.size());
   }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -291,16 +291,16 @@ public class StorageHandlerTest {
     expected.add(StorageHandlerTestHelper.createTestClubObject("clubs2", /* contentWarning= */true));
     expected.add(StorageHandlerTestHelper.createTestClubObject("clubs3", /* contentWarning= */true));
 
-    StorageHandlerTestHelper.insertPerson("non-member");
+    StorageHandlerTestHelper.insertPerson("member");
     StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
     StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
     StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
-    StorageHandlerTestHelper.insertMembership("non-member", "clubs1", MembershipConstants.MEMBER);
-    StorageHandlerTestHelper.insertMembership("non-member", "clubs2", MembershipConstants.MEMBER);
-    StorageHandlerTestHelper.insertMembership("non-member", "clubs3", MembershipConstants.MEMBER);
+    StorageHandlerTestHelper.insertMembership("member", "clubs1", MembershipConstants.MEMBER);
+    StorageHandlerTestHelper.insertMembership("member", "clubs2", MembershipConstants.MEMBER);
+    StorageHandlerTestHelper.insertMembership("member", "clubs3", MembershipConstants.MEMBER);
     StorageHandlerTestHelper.insertBook("book");
     
-    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "non-member",
+    List<Club> actual =  new ArrayList<Club>(StorageHandler.getListOfClubs(dbClient, "member",
                                              MembershipConstants.MembershipStatus.MEMBER));
 
     assertEquals(3, actual.size());
@@ -357,5 +357,26 @@ public class StorageHandlerTest {
       assertEquals(actual.get(i).getDescription(), expected.get(i).getDescription());
       assertEquals(actual.get(i).getCurrentBook().getTitle(), expected.get(i).getCurrentBook().getTitle());
     }
+  }
+
+  @Test
+  public void getListOfClubs_notMemberThrowsException() throws Exception {
+    List<Club> expected = new ArrayList<Club>();
+    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs1", /* contentWarning= */true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs2", /* contentWarning= */true));
+    expected.add(StorageHandlerTestHelper.createTestClubObject("clubs3", /* contentWarning= */true));
+    StorageHandlerTestHelper.insertPerson("member");
+    StorageHandlerTestHelper.insertPerson("owner");    
+    StorageHandlerTestHelper.insertClub("clubs1", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs2", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertClub("clubs3", /* owner_id= */"owner");
+    StorageHandlerTestHelper.insertBook("book");
+    StorageHandlerTestHelper.insertMembership("member", "clubs1", MembershipConstants.MEMBER);
+    StorageHandlerTestHelper.insertMembership("member", "clubs2", MembershipConstants.MEMBER);
+    StorageHandlerTestHelper.insertMembership("member", "clubs3", MembershipConstants.MEMBER);
+    assertThrows(RuntimeException.class, () -> {
+      StorageHandler.getListOfClubs(
+        dbClient, "member", MembershipConstants.MembershipStatus.NOT_MEMBER);
+    });
   }
 }

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTest.java
@@ -308,7 +308,7 @@ public class StorageHandlerTest {
 
     assertEquals(3, actual.size());
     assertEquals(expected.size(), actual.size());
-    for (int i =0; i < actual.size(); i++) {
+    for (int i = 0; i < actual.size(); i++) {
       assertEquals(actual.get(i).getName(), expected.get(i).getName());
       assertEquals(actual.get(i).getOwnerId(), expected.get(i).getOwnerId());
       assertEquals(actual.get(i).getClubId(), expected.get(i).getClubId());
@@ -356,7 +356,7 @@ public class StorageHandlerTest {
                                              MembershipConstants.MembershipStatus.NOT_MEMBER));
     assertEquals(3, actual.size());
     assertEquals(expected.size(), actual.size());
-    for (int i =0; i < actual.size(); i++) {
+    for (int i = 0; i < actual.size(); i++) {
       assertEquals(actual.get(i).getName(), expected.get(i).getName());
       assertEquals(actual.get(i).getOwnerId(), expected.get(i).getOwnerId());
       assertEquals(actual.get(i).getClubId(), expected.get(i).getClubId());

--- a/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTestHelper.java
+++ b/server/src/test/java/com/google/coffeehouse/storagehandler/StorageHandlerTestHelper.java
@@ -73,6 +73,26 @@ public class StorageHandlerTestHelper {
     dbClient.write(mutations);
   }
 
+  public static void insertClub(String club_id, String owner_id) {
+    List<Mutation> mutations = new ArrayList<>();
+    mutations.add(
+      Mutation.newInsertOrUpdateBuilder("Clubs")
+        .set("clubId")
+        .to(club_id)
+        .set("bookId")
+        .to("book")
+        .set("description")
+        .to("description")
+        .set("name")
+        .to("club")
+        .set("ownerId")
+        .to(owner_id)
+        .set("timestamp")
+        .to(Value.COMMIT_TIMESTAMP)
+        .build());
+    dbClient.write(mutations);
+  }
+
   public static void insertClubWithNoContentWarnings(String club_id) {
     List<Mutation> mutations = new ArrayList<>();
     mutations.add(


### PR DESCRIPTION
Add tests for `getListOfMembers` and `getListOfClubs`.
Refactor `runDeleteMembershipTransaction` in order to not allow owners to leave their own clubs.
Add tests to ensure that owners can not leave their club when calling `runDeleteMembershipTransaction`.
Change /api/leave-club to account for new errors thrown due to exceptions when owners attempt to leave their own clubs. Refactor `getListOfMembers` to not call `getMemberCount`, but rather return an exception if the list of members is empty (indicating there are none, which is impossible because at least there must be an owner).
Add tests for api/list-clubs to succesfully return an empty list of clubs if there are no clubs a user is not a member of (explore), or no clubs that a user is a member of (your-clubs).
Closes #91 .